### PR TITLE
Adding XDEBUG_MODE=coverage for executing PHPUnit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,9 @@
     </report>
   </coverage>
   <logging/>
+  <php>
+    <ini name="XDEBUG_MODE" value="coverage" />
+  </php>
   <testsuites>
     <testsuite name="unit">
       <directory suffix=".php">tests/Flow/ETL/Tests/Unit</directory>


### PR DESCRIPTION
# Changed log

- Adding the `XDEBUG_MODE=coverage` setting to resolve warning message when running PHPUnit:

```
Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set
```