### PR TITLE
Added filter rows transformer

### DIFF
--- a/src/Flow/ETL/Transformer/Filter.php
+++ b/src/Flow/ETL/Transformer/Filter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Transformer;
+
+use Flow\ETL\Row;
+
+/**
+ * @psalm-immutable
+ */
+interface Filter
+{
+    public function __invoke(Row $row) : bool;
+}

--- a/src/Flow/ETL/Transformer/FilterRows.php
+++ b/src/Flow/ETL/Transformer/FilterRows.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Transformer;
+
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use Flow\ETL\Transformer;
+
+/**
+ * @psalm-immutable
+ */
+final class FilterRows implements Transformer
+{
+    /**
+     * @var Filter[]
+     */
+    private array $filters;
+
+    /**
+     * @psalm-suppress ImpurePropertyAssignment
+     */
+    public function __construct(Filter ...$filters)
+    {
+        $this->filters = $filters;
+    }
+
+    public function transform(Rows $rows) : Rows
+    {
+        return $rows->filter(
+            function (Row $row) {
+                foreach ($this->filters as $filter) {
+                    if (false === $filter($row)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        );
+    }
+}

--- a/tests/Flow/ETL/Tests/Double/FilterPendingRows.php
+++ b/tests/Flow/ETL/Tests/Double/FilterPendingRows.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Double;
+
+use Flow\ETL\Row;
+use Flow\ETL\Transformer\Filter;
+
+final class FilterPendingRows implements Filter
+{
+    public function __invoke(Row $row) : bool
+    {
+        return $row->valueOf('status') !== 'PENDING';
+    }
+}

--- a/tests/Flow/ETL/Tests/Double/FilterShippedRows.php
+++ b/tests/Flow/ETL/Tests/Double/FilterShippedRows.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Double;
+
+use Flow\ETL\Row;
+use Flow\ETL\Transformer\Filter;
+
+final class FilterShippedRows implements Filter
+{
+    public function __invoke(Row $row) : bool
+    {
+        return $row->valueOf('status') !== 'SHIPPED';
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Transformer/FilterRowsTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Transformer/FilterRowsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Transformer;
+
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use Flow\ETL\Tests\Double\FilterPendingRows;
+use Flow\ETL\Tests\Double\FilterShippedRows;
+use Flow\ETL\Transformer\FilterRows;
+use PHPUnit\Framework\TestCase;
+
+final class FilterRowsTest extends TestCase
+{
+    public function test_filter_rows() : void
+    {
+        $filterRows = new FilterRows(
+            new FilterPendingRows(),
+            new FilterShippedRows()
+        );
+
+        $rows = $filterRows->transform(
+            new Rows(
+                Row::create(new Row\Entry\StringEntry('status', 'PENDING')),
+                Row::create(new Row\Entry\StringEntry('status', 'SHIPPED')),
+                Row::create(new Row\Entry\StringEntry('status', 'NEW')),
+            )
+        );
+
+        $this->assertEquals(
+            [
+                ['status' => 'NEW'],
+            ],
+            $rows->toArray()
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added FilterRow</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Instead of creating new transformers only for filtering rows we can use `FilterRow` transformer and avoid iterating multiple times over the same rows.