### PR TITLE
Improve return type for Rows::toArray()

### DIFF
--- a/src/Flow/ETL/Row.php
+++ b/src/Flow/ETL/Row.php
@@ -101,7 +101,7 @@ final class Row
     }
 
     /**
-     * @phpstan-ignore-next-line
+     * @return array<string, mixed>
      */
     public function toArray() : array
     {

--- a/src/Flow/ETL/Row/Entries.php
+++ b/src/Flow/ETL/Row/Entries.php
@@ -121,8 +121,9 @@ final class Entries implements \Countable
     }
 
     /**
-     * @phpstan-ignore-next-line
      * @psalm-suppress MissingClosureReturnType
+     *
+     * @return array<string, mixed>
      */
     public function toArray() : array
     {

--- a/src/Flow/ETL/Rows.php
+++ b/src/Flow/ETL/Rows.php
@@ -155,7 +155,7 @@ final class Rows
     }
 
     /**
-     * @return array<mixed>
+     * @return array<int, array<string, mixed>>
      */
     public function toArray() : array
     {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
<li>Improved return type for Row::toArray()</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

I noticed that the return type can be more specific than it is.