### PR TITLE
Add merge method for Rows

### DIFF
--- a/src/Flow/ETL/Rows.php
+++ b/src/Flow/ETL/Rows.php
@@ -264,7 +264,6 @@ final class Rows
         );
     }
 
-    // fixme test
     public function merge(self $rows) : self
     {
         return new self(

--- a/src/Flow/ETL/Rows.php
+++ b/src/Flow/ETL/Rows.php
@@ -140,9 +140,9 @@ final class Rows
     }
 
     /**
-     * @psalm-param pure-callable(Row) : Row $callable
+     * @psalm-param pure-callable(Row) : void $callable
      *
-     * @param callable(Row) : Row $callable
+     * @param callable(Row) : void $callable
      */
     public function each(callable $callable) : void
     {
@@ -261,6 +261,14 @@ final class Rows
     {
         return new self(
             ...\array_merge($this->rows, [$row])
+        );
+    }
+
+    // fixme test
+    public function merge(self $rows) : self
+    {
+        return new self(
+            ...\array_merge($this->rows, $rows->rows)
         );
     }
 }

--- a/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -311,4 +311,30 @@ final class RowsTest extends TestCase
             $right = new Rows(Row::create(new IntegerEntry('number', 1))),
         ];
     }
+
+    public function test_merges_two_collection_together() : void
+    {
+        $rowsOne = new Rows(
+            Row::create(new IntegerEntry('id', 1)),
+            Row::create(new IntegerEntry('id', 2)),
+        );
+        $rowsTwo = new Rows(
+            Row::create(new IntegerEntry('id', 3)),
+            Row::create(new IntegerEntry('id', 4)),
+            Row::create(new IntegerEntry('id', 5))
+        );
+
+        $merged = $rowsOne->merge($rowsTwo);
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(new IntegerEntry('id', 1)),
+                Row::create(new IntegerEntry('id', 2)),
+                Row::create(new IntegerEntry('id', 3)),
+                Row::create(new IntegerEntry('id', 4)),
+                Row::create(new IntegerEntry('id', 5))
+            ),
+            $merged
+        );
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>merge() method for rows</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

I have a use case for merging two collections of rows together. It should be generic enough to add as a part of the library.