### PR TITLE
Cleanup Entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This is a perfect scenario for ETL.
 * Low memory consumption even when processing thousands of records
 * Type safe Rows/Row/Entry abstractions
 * Filtering
-* Grouping
 * Built in Rows objects comparison
 * Rich collection of Entry implementations
   * [ArrayEntry](src/Flow/ETL/Row/Entry/ArrayEntry.php)
@@ -42,6 +41,13 @@ This is a perfect scenario for ETL.
   * [NullEntry](src/Flow/ETL/Row/Entry/NullEntry.php)
   * [ObjectEntryEntry](src/Flow/ETL/Row/Entry/ObjectEntry.php)
   * [StringEntry](src/Flow/ETL/Row/Entry/StringEntry.php)
+
+## Adapters
+
+* [Doctrine](https://github.com/flow-php/etl-adapter-doctrine)
+* [CSV](https://github.com/flow-php/etl-adapter-csv)
+* Elasticsearch - TODO
+* XML - TODO
 
 ## Installation
 

--- a/src/Flow/ETL/Row.php
+++ b/src/Flow/ETL/Row.php
@@ -8,7 +8,6 @@ use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row\Converter;
 use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Entry;
-use Flow\ETL\Row\Entry\CollectionEntry;
 
 /**
  * @psalm-immutable
@@ -75,23 +74,10 @@ final class Row
         );
     }
 
-    public function pullOutFrom(string $collectionName, string $entryName) : self
-    {
-        $collection = $this->get($collectionName);
-
-        if (!$collection instanceof CollectionEntry) {
-            throw RuntimeException::because('Entry can be pulled out only from "%s", but "%s" is a "%s"', CollectionEntry::class, $collectionName, \get_class($collection));
-        }
-
-        return $this
-            ->set($collection->entryFromAll($entryName))
-            ->set($collection->removeFromAll($entryName));
-    }
-
-    public function convert(string $name, Converter $serializer) : self
+    public function convert(string $name, Converter $converter) : self
     {
         return $this->set(
-            $serializer->convert($this->get($name))
+            $converter->convert($this->get($name))
         );
     }
 

--- a/src/Flow/ETL/Row/Entries.php
+++ b/src/Flow/ETL/Row/Entries.php
@@ -7,7 +7,6 @@ namespace Flow\ETL\Row;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\InvalidLogicException;
 use Flow\ETL\Exception\RuntimeException;
-use Flow\ETL\Row\Entry\CollectionEntry;
 
 /**
  * @psalm-immutable
@@ -78,19 +77,6 @@ final class Entries implements \Countable
         }
 
         return $this->add($entry);
-    }
-
-    public function appendTo(string $name, self $entries) : self
-    {
-        $entry = $this->get($name);
-
-        if (!$entry instanceof CollectionEntry) {
-            throw RuntimeException::because('Entries can be appended only to "%s", "%s" is type of "%s"', CollectionEntry::class, $name, \get_class($entry));
-        }
-
-        return $this
-            ->remove($name)
-            ->add($entry->append($entries));
     }
 
     public function sort() : self

--- a/src/Flow/ETL/Rows.php
+++ b/src/Flow/ETL/Rows.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL;
 
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row\Comparator;
 use Flow\ETL\Row\Comparator\NativeComparator;
-use Flow\ETL\Row\Entries;
-use Flow\ETL\Row\Entry;
-use Flow\ETL\Row\Entry\CollectionEntry;
 
 /**
  * @psalm-immutable
@@ -27,35 +23,6 @@ final class Rows
     public function __construct(Row ...$rows)
     {
         $this->rows = $rows;
-    }
-
-    /**
-     * @psalm-suppress MixedArgument
-     * @pslam-param callable (Row) : string|int|float $groupBy  Returns group identifier for the given Row
-     */
-    public function groupTo(string $collectionEntryName, callable $groupBy) : self
-    {
-        return new self(
-            ...\array_reduce(
-                $this->rows,
-                function (Entries $entries, Row $row) use ($groupBy) : Entries {
-                    $name = (string) $groupBy($row);
-
-                    if (empty($name)) {
-                        throw InvalidArgumentException::because('Group name for grouping rows cannot be empty');
-                    }
-
-                    if ($entries->has($name)) {
-                        return $entries->appendTo($name, $row->entries());
-                    }
-
-                    return $entries->add(new CollectionEntry($name, $row->entries()));
-                },
-                new Entries()
-            )->map(
-                fn (Entry $entry) => Row::create($entry->rename($collectionEntryName))
-            )
-        );
     }
 
     /**

--- a/tests/Flow/ETL/Tests/Unit/Row/EntriesTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/EntriesTest.php
@@ -100,43 +100,6 @@ final class EntriesTest extends TestCase
         $this->assertEquals(new Entries($booleanEntry, $stringEntry), $entries);
     }
 
-    public function test_appends_entries_to_collection_entry() : void
-    {
-        $one   = new Entries(new IntegerEntry('id', 1), new StringEntry('name', 'one'));
-        $two   = new Entries(new IntegerEntry('id', 2), new StringEntry('name', 'two'));
-        $three = new Entries(new IntegerEntry('id', 3), new StringEntry('name', 'three'));
-        $entries = new Entries(
-            $integerEntry = new IntegerEntry('integer-entry', 100),
-            new CollectionEntry('collection-entry', $one)
-        );
-
-        $entries = $entries
-            ->appendTo('collection-entry', $two)
-            ->appendTo('collection-entry', $three);
-
-        $this->assertEquals(
-            new Entries(
-                $integerEntry,
-                new CollectionEntry('collection-entry', $one, $two, $three)
-            ),
-            $entries
-        );
-    }
-
-    public function test_prevents_from_appending_entries_to_non_collection_entry() : void
-    {
-        $entries = new Entries(
-            $integerEntry = new IntegerEntry('integer-entry', 100),
-        );
-
-        $this->expectExceptionMessage('Entries can be appended only to');
-
-        $entries->appendTo(
-            'integer-entry',
-            new Entries(new IntegerEntry('id', 1), new StringEntry('name', 'one'))
-        );
-    }
-
     public function test_prevents_from_getting_unknown_entry() : void
     {
         $entries = new Entries();

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/CollectionEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/CollectionEntryTest.php
@@ -24,66 +24,6 @@ final class CollectionEntryTest extends TestCase
         );
     }
 
-    public function test_appends_entries() : void
-    {
-        $one   = new Entries(new IntegerEntry('id', 1), new StringEntry('name', 'one'));
-        $two   = new Entries(new IntegerEntry('id', 2), new StringEntry('name', 'two'));
-        $three = new Entries(new IntegerEntry('id', 3), new StringEntry('name', 'three'));
-        $entry = new CollectionEntry('collection-entry', $one);
-
-        $entry = $entry
-            ->append($two)
-            ->append($three);
-
-        $this->assertEquals(new CollectionEntry('collection-entry', $one, $two, $three), $entry);
-    }
-
-    public function test_gets_entry_from_all_entries_when_value_is_the_same() : void
-    {
-        $orderIdEntry = new IntegerEntry('order-id', 1);
-        $entry = new CollectionEntry(
-            'items',
-            new Entries($orderIdEntry, new StringEntry('item-name', 'one')),
-            new Entries($orderIdEntry, new StringEntry('item-name', 'two')),
-            new Entries(new IntegerEntry('order-id', 1), new StringEntry('item-name', 'three')),
-        );
-
-        $this->assertEquals($orderIdEntry, $entry->entryFromAll('order-id'));
-    }
-
-    public function test_prevents_from_getting_entry_when_value_is_different() : void
-    {
-        $entry = new CollectionEntry(
-            'items',
-            new Entries(new IntegerEntry('order-id', 1), new StringEntry('item-name', 'one')),
-            new Entries(new IntegerEntry('order-id', 2), new StringEntry('item-name', 'two')),
-        );
-
-        $this->expectExceptionMessage('Entry "order-id" has different values in "items" collection entry');
-
-        $entry->entryFromAll('order-id');
-    }
-
-    public function test_removes_entry_from_all_entries() : void
-    {
-        $entry = new CollectionEntry(
-            'items',
-            new Entries(new IntegerEntry('order-id', 1), new StringEntry('item-name', 'one')),
-            new Entries(new IntegerEntry('order-id', 2), new StringEntry('item-name', 'two')),
-            new Entries(new IntegerEntry('order-id', 3), new StringEntry('item-name', 'three'))
-        );
-
-        $this->assertEquals(
-            new CollectionEntry(
-                'items',
-                new Entries(new StringEntry('item-name', 'one')),
-                new Entries(new StringEntry('item-name', 'two')),
-                new Entries(new StringEntry('item-name', 'three'))
-            ),
-            $entry->removeFromAll('order-id'),
-        );
-    }
-
     public function test_returns_array_as_value() : void
     {
         $entry = new CollectionEntry(

--- a/tests/Flow/ETL/Tests/Unit/RowTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowTest.php
@@ -38,41 +38,6 @@ final class RowTest extends TestCase
         );
     }
 
-    public function test_pull_outs_entry_from_collection_entry() : void
-    {
-        $orderId = new IntegerEntry('order-id', 1234);
-        $row = Row::create(
-            new CollectionEntry(
-                'items',
-                new Entries($orderId, new IntegerEntry('item-id', 1), new StringEntry('name', 'one')),
-                new Entries($orderId, new IntegerEntry('item-id', 2), new StringEntry('name', 'two')),
-                new Entries($orderId, new IntegerEntry('item-id', 3), new StringEntry('name', 'three'))
-            )
-        );
-
-        $this->assertEquals(
-            Row::create(
-                $orderId,
-                new CollectionEntry(
-                    'items',
-                    new Entries(new IntegerEntry('item-id', 1), new StringEntry('name', 'one')),
-                    new Entries(new IntegerEntry('item-id', 2), new StringEntry('name', 'two')),
-                    new Entries(new IntegerEntry('item-id', 3), new StringEntry('name', 'three'))
-                )
-            ),
-            $row->pullOutFrom('items', 'order-id'),
-        );
-    }
-
-    public function test_prevents_from_pulling_out_entry_from_non_collection_entry() : void
-    {
-        $row = Row::create(new IntegerEntry('id', 1), new StringEntry('name', 'one'));
-
-        $this->expectExceptionMessage('Entry can be pulled out only from');
-
-        $row->pullOutFrom('id', 'name');
-    }
-
     public function test_converts_one_entry_into_another_using_converter() : void
     {
         $row = Row::create(new StringEntry('name', 'one'), new IntegerEntry('id', 1));


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Rows::groupTo() : self</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Grouping was removed from Rows, this feature was complex to use and to understand but also it wasn't good fit for the whole ETL. 
In order to be memory safe extractors are extracting only chunks of the whole dataset passing it to transformers and then loaders, this is how it can be visualized:

Let's say this is our whole dataset: 
```
id, sub_id
1, 1
1, 2
2, 1
2, 2
3, 1
3, 2
4, 1
4, 2
5, 1
5, 2
```
Let's assume that our goal is to transform this dataset into something like: 

```
id, sub_ids
1, [1, 2]
2, [1, 2]
3, [1, 2]
4, [1, 2]
5, [1, 2]
```

This was the use case for Rows::groupTo however...
In order to make ETL memory safe, we need to divide the dataset into chunks, let's say 5 rows each.
(of course, this is a trivial and simplified example, but think about this dataset like about 5Gb CSV file that you need to process).

Chunk 1
```
id, sub_id
1, 1
1, 2
2, 1
2, 2
3, 1
```

Chunk 2
```
id, sub_id
3, 2
4, 1
4, 2
5, 1
5, 2
```

Grouping was allowing us to group things together (in this example, sub_ids could be grouped into collection entry) and put them into new entries however when working with memory-safe, partial datasets there is a good chance that not all things that should be grouped together will exist in currently processed data chunk. 

### How then deal with grouping?

One solution would be to create another ETL that will take the whole dataset, find all rows with the given id and load them into a variable (create a loader that will receive array through reference into which it will values).
We need to think if there is any better way since creating 2 ETL's to process one file does not sound right but it should work if anyone would need that now. 

 