### PR TITLE
Allow entries to take any string as a name

### DIFF
--- a/src/Flow/ETL/Row/Entry/ArrayEntry.php
+++ b/src/Flow/ETL/Row/Entry/ArrayEntry.php
@@ -27,7 +27,7 @@ final class ArrayEntry implements Entry
      */
     public function __construct(string $name, array $value)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/BooleanEntry.php
+++ b/src/Flow/ETL/Row/Entry/BooleanEntry.php
@@ -20,7 +20,7 @@ final class BooleanEntry implements Entry
 
     public function __construct(string $name, bool $value)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/CollectionEntry.php
+++ b/src/Flow/ETL/Row/Entry/CollectionEntry.php
@@ -25,7 +25,7 @@ final class CollectionEntry implements Entry
 
     public function __construct(string $name, Entries ...$entries)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/DateEntry.php
+++ b/src/Flow/ETL/Row/Entry/DateEntry.php
@@ -20,7 +20,7 @@ final class DateEntry implements Entry
 
     public function __construct(string $name, \DateTimeImmutable $value)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/DateTimeEntry.php
+++ b/src/Flow/ETL/Row/Entry/DateTimeEntry.php
@@ -22,7 +22,7 @@ final class DateTimeEntry implements Entry
 
     public function __construct(string $name, \DateTimeImmutable $value, string $format = \DateTimeImmutable::ATOM)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/IntegerEntry.php
+++ b/src/Flow/ETL/Row/Entry/IntegerEntry.php
@@ -20,7 +20,7 @@ final class IntegerEntry implements Entry
 
     public function __construct(string $name, int $value)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/JsonEntry.php
+++ b/src/Flow/ETL/Row/Entry/JsonEntry.php
@@ -29,7 +29,7 @@ final class JsonEntry implements Entry
      */
     public function __construct(string $name, array $value)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/NullEntry.php
+++ b/src/Flow/ETL/Row/Entry/NullEntry.php
@@ -18,7 +18,7 @@ final class NullEntry implements Entry
 
     public function __construct(string $name)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/ObjectEntry.php
+++ b/src/Flow/ETL/Row/Entry/ObjectEntry.php
@@ -20,7 +20,7 @@ final class ObjectEntry implements Entry
 
     public function __construct(string $name, object $value)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/StringEntry.php
+++ b/src/Flow/ETL/Row/Entry/StringEntry.php
@@ -20,7 +20,7 @@ final class StringEntry implements Entry
 
     public function __construct(string $name, string $value)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/Flow/ETL/Row/Entry/XMLEntry.php
+++ b/src/Flow/ETL/Row/Entry/XMLEntry.php
@@ -20,7 +20,7 @@ final class XMLEntry implements Entry
 
     public function __construct(string $name, \DOMDocument $value)
     {
-        if (empty($name)) {
+        if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/ArrayEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/ArrayEntryTest.php
@@ -17,6 +17,11 @@ final class ArrayEntryTest extends TestCase
         new ArrayEntry('', ['id' => 1]);
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new ArrayEntry('0', ['id' => 1]))->name());
+    }
+
     public function test_renames_entry() : void
     {
         $entry = new ArrayEntry('entry-name', ['id' => 1, 'name' => 'one']);

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/BooleanEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/BooleanEntryTest.php
@@ -16,6 +16,11 @@ final class BooleanEntryTest extends TestCase
         new BooleanEntry('', true);
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new BooleanEntry('0', true))->name());
+    }
+
     public function test_renames_entry() : void
     {
         $entry = new BooleanEntry('entry-name', true);

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/CollectionEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/CollectionEntryTest.php
@@ -24,6 +24,11 @@ final class CollectionEntryTest extends TestCase
         );
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new CollectionEntry('0', new Entries(new IntegerEntry('id', 1), new StringEntry('name', 'one'))))->name());
+    }
+
     public function test_returns_array_as_value() : void
     {
         $entry = new CollectionEntry(

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/DateEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/DateEntryTest.php
@@ -16,6 +16,11 @@ final class DateEntryTest extends TestCase
         new DateEntry('', new \DateTimeImmutable('2020-07-13 12:00'));
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new DateEntry('0', new \DateTimeImmutable('2020-07-13 12:00')))->name());
+    }
+
     public function test_trims_time_to_begin_of_a_day() : void
     {
         $entry = new DateEntry('entry-name', new \DateTimeImmutable('2020-07-13 12:00'));

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/DateTimeEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/DateTimeEntryTest.php
@@ -16,6 +16,11 @@ final class DateTimeEntryTest extends TestCase
         new DateTimeEntry('', new \DateTimeImmutable('2020-07-13 12:00'));
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new DateTimeEntry('0', new \DateTimeImmutable('2020-07-13 12:00')))->name());
+    }
+
     public function test_uses_full_date_time() : void
     {
         $entry = new DateTimeEntry('entry-name', new \DateTimeImmutable('2020-07-13 12:00'));

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/IntegerEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/IntegerEntryTest.php
@@ -16,6 +16,11 @@ final class IntegerEntryTest extends TestCase
         new IntegerEntry('', 100);
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new IntegerEntry('0', 0))->name());
+    }
+
     public function test_renames_entry() : void
     {
         $entry = new IntegerEntry('entry-name', 100);

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonEntryTest.php
@@ -17,6 +17,11 @@ final class JsonEntryTest extends TestCase
         new JsonEntry('', [1, 2, 3]);
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new JsonEntry('0', [1]))->name());
+    }
+
     public function test_prevent_from_creating_object_with_integers_as_keys_in_entry() : void
     {
         $this->expectExceptionMessage('All keys for JsonEntry object must be strings');

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/NullEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/NullEntryTest.php
@@ -16,6 +16,11 @@ final class NullEntryTest extends TestCase
         new NullEntry('');
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new NullEntry('0'))->name());
+    }
+
     public function test_renames_entry() : void
     {
         $entry = new NullEntry('entry-name');

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/ObjectEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/ObjectEntryTest.php
@@ -16,6 +16,11 @@ final class ObjectEntryTest extends TestCase
         new ObjectEntry('', new \stdClass());
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (new ObjectEntry('0', new \stdClass()))->name());
+    }
+
     public function test_renames_entry() : void
     {
         $entry = new ObjectEntry('entry-name', new \stdClass());

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/XMLEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/XMLEntryTest.php
@@ -16,6 +16,11 @@ final class XMLEntryTest extends TestCase
         XMLEntry::fromString('', '<xml><name>node</name></xml>');
     }
 
+    public function test_entry_name_can_be_zero() : void
+    {
+        $this->assertSame('0', (XMLEntry::fromString('0', '<xml><name>node</name></xml>'))->name());
+    }
+
     public function test_returns_json_as_value() : void
     {
         $xml = '<xml><name>node</name></xml>';


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>not allowing '0' string as a name</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->