### PR TITLE
Added precision to the float entry in order to fix comparisons

### DIFF
--- a/src/Flow/ETL/Row/Entry/FloatEntry.php
+++ b/src/Flow/ETL/Row/Entry/FloatEntry.php
@@ -18,7 +18,9 @@ final class FloatEntry implements Entry
 
     private float $value;
 
-    public function __construct(string $name, float $value)
+    private int $precision;
+
+    public function __construct(string $name, float $value, int $precision = 6)
     {
         if (!\strlen($name)) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
@@ -27,6 +29,7 @@ final class FloatEntry implements Entry
         $this->key = \mb_strtolower($name);
         $this->name = $name;
         $this->value = $value;
+        $this->precision = $precision;
     }
 
     /**
@@ -76,6 +79,6 @@ final class FloatEntry implements Entry
     {
         return $this->is($entry->name())
             && $entry instanceof self
-            && \bccomp((string) $this->value(), (string) $entry->value()) === 0;
+            && \bccomp((string) $this->value(), (string) $entry->value(), $this->precision) === 0;
     }
 }

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/FloatEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/FloatEntryTest.php
@@ -94,6 +94,8 @@ final class FloatEntryTest extends TestCase
         yield 'equal names and values' => [true, new FloatEntry('name', 1.0), new FloatEntry('name', 1.0)];
         yield 'different names and values' => [false, new FloatEntry('name', 1.0), new FloatEntry('different_name', 1.0)];
         yield 'equal names and different values' => [false, new FloatEntry('name', 1.0), new FloatEntry('name', 2)];
-        yield 'different names characters and equal values' => [true, new FloatEntry('NAME', 1.), new FloatEntry('name', 1.1)];
+        yield 'different names characters and equal values' => [true, new FloatEntry('NAME', 1.1), new FloatEntry('name', 1.1)];
+        yield 'different names characters and equal values with high precision' => [true, new FloatEntry('NAME', 1.00001), new FloatEntry('name', 1.00001)];
+        yield 'different names characters and different values with high precision' => [false, new FloatEntry('NAME', 1.205502), new FloatEntry('name', 1.205501)];
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>FloatEntry comparison by using precision properly</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->