### PR TITLE
Added access methods to Rows and Entries

### DIFF
--- a/src/Flow/ETL/Row/Entries.php
+++ b/src/Flow/ETL/Row/Entries.php
@@ -9,9 +9,11 @@ use Flow\ETL\Exception\InvalidLogicException;
 use Flow\ETL\Exception\RuntimeException;
 
 /**
+ * @implements \ArrayAccess<string, Entry>
+ * @implements \IteratorAggregate<string, Entry>
  * @psalm-immutable
  */
-final class Entries implements \Countable
+final class Entries  implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
      * @var Entry[]
@@ -27,6 +29,65 @@ final class Entries implements \Countable
         }
 
         $this->entries = $entries;
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return bool
+     */
+    public function offsetExists($offset) : bool
+    {
+        /** @psalm-suppress DocblockTypeContradiction */
+        if (!\is_string($offset)) {
+            throw new InvalidArgumentException('Entries accepts only string offsets');
+        }
+
+        return $this->has($offset);
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return Entry
+     */
+    public function offsetGet($offset) : Entry
+    {
+        if ($this->offsetExists($offset)) {
+            return $this->get($offset);
+        }
+
+        throw new InvalidArgumentException("Entry {$offset} does not exists.");
+    }
+
+    public function offsetSet($offset, $value) : self
+    {
+        throw new RuntimeException('In order to add new rows use Entries::add(Entry $entry) : self');
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return Entries
+     * @psalm-suppress ImplementedReturnTypeMismatch
+     */
+    public function offsetUnset($offset) : self
+    {
+        throw new RuntimeException('In order to add new rows use Entries::remove(string $name) : self');
+    }
+
+    /**
+     * @return \Iterator<string, Entry>
+     */
+    public function getIterator() : \Iterator
+    {
+        return new \ArrayIterator($this->entries);
     }
 
     public function has(string $name) : bool

--- a/tests/Flow/ETL/Tests/Unit/Row/EntriesTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/EntriesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Row;
 
+use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Entry\BooleanEntry;
 use Flow\ETL\Row\Entry\CollectionEntry;
@@ -176,5 +177,37 @@ final class EntriesTest extends TestCase
             ),
             $sorted
         );
+    }
+
+    public function test_array_access_get() : void
+    {
+        $entries = new Entries(new IntegerEntry('id', 1), new StringEntry('name', 'John'));
+
+        $this->assertSame(1, $entries['id']->value());
+        $this->assertSame('John', $entries['name']->value());
+    }
+
+    public function test_array_access_exists() : void
+    {
+        $entries = new Entries(new IntegerEntry('id', 1), new StringEntry('name', 'John'));
+
+        $this->assertTrue(isset($entries['id']));
+        $this->assertFalse(isset($entries['test']));
+    }
+
+    public function test_array_access_set() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('In order to add new rows use Entries::add(Entry $entry) : self');
+        $entries = new Entries();
+        $entries['id'] = new IntegerEntry('id', 1);
+    }
+
+    public function test_array_access_unset() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('In order to add new rows use Entries::remove(string $name) : self');
+        $entries = new Entries(new IntegerEntry('id', 1));
+        unset($entries['id']);
     }
 }

--- a/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit;
 
+use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Entry\BooleanEntry;
 use Flow\ETL\Row\Entry\DateTimeEntry;
@@ -370,5 +371,61 @@ final class RowsTest extends TestCase
             ],
             $rows->toArray()
         );
+    }
+
+    public function test_array_access_get() : void
+    {
+        $rows = new Rows(
+            Row::create(new IntegerEntry('id', 1)),
+            Row::create(new IntegerEntry('id', 2)),
+            Row::create(new IntegerEntry('id', 3)),
+        );
+
+        $this->assertSame(1, $rows[0]->valueOf('id'));
+        $this->assertSame(2, $rows[1]->valueOf('id'));
+        $this->assertSame(3, $rows[2]->valueOf('id'));
+    }
+
+    public function test_array_access_exists() : void
+    {
+        $rows = new Rows(
+            Row::create(new IntegerEntry('id', 1)),
+            Row::create(new IntegerEntry('id', 2)),
+            Row::create(new IntegerEntry('id', 3)),
+        );
+
+        $this->assertTrue(isset($rows[0]));
+        $this->assertFalse(isset($rows[3]));
+    }
+
+    public function test_array_access_set() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('In order to add new rows use Rows::add(Row $row) : self');
+        $rows = new Rows();
+        $rows[0] = Row::create(new IntegerEntry('id', 1));
+    }
+
+    public function test_array_access_unset() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('In order to add new rows use Rows::remove(int $offset) : self');
+        $rows = new Rows(Row::create(new IntegerEntry('id', 1)));
+        unset($rows[0]);
+    }
+
+    public function test_remove() : void
+    {
+        $rows = new Rows(
+            Row::create(new IntegerEntry('id', 1)),
+            Row::create(new IntegerEntry('id', 2)),
+            Row::create(new IntegerEntry('id', 3)),
+        );
+
+        $rows = $rows->remove(1);
+
+        $this->assertCount(2, $rows);
+        $this->assertSame(1, $rows[0]->valueOf('id'));
+        $this->assertSame(3, $rows[1]->valueOf('id'));
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Rows implements interfaces \ArrayAccess, \Countable, \IteratorAggregate</li>
    <li>Enties implements interfaces \ArrayAccess, \Countable, \IteratorAggregate</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->