### PR TITLE
Added detecting first/last Rows inside of ETL

### DIFF
--- a/src/Flow/ETL/Rows.php
+++ b/src/Flow/ETL/Rows.php
@@ -23,9 +23,43 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     private array $rows;
 
+    private bool $first;
+
+    private bool $last;
+
     public function __construct(Row ...$rows)
     {
         $this->rows = $rows;
+        $this->first = true;
+        $this->last = false;
+    }
+
+    public function makeFirst() : self
+    {
+        $rows = new self(...$this->rows);
+        $rows->first = true;
+        $rows->last = $this->last;
+
+        return $rows;
+    }
+
+    public function makeLast() : self
+    {
+        $rows = new self(...$this->rows);
+        $rows->last = true;
+        $rows->first = $this->first;
+
+        return $rows;
+    }
+
+    public function isFirst() : bool
+    {
+        return $this->first;
+    }
+
+    public function isLast() : bool
+    {
+        return $this->last;
     }
 
     /**

--- a/src/Flow/ETL/SynchronousPipeline.php
+++ b/src/Flow/ETL/SynchronousPipeline.php
@@ -28,10 +28,26 @@ final class SynchronousPipeline implements Pipeline
      */
     public function process(\Generator $generator) : void
     {
-        foreach ($generator as $rows) {
+        $index = 0;
+
+        while ($generator->valid()) {
+            /** @var Rows $rows */
+            $rows = $generator->current();
+            $generator->next();
+
+            if ($index === 0) {
+                $rows = $rows->makeFirst();
+            }
+
+            if ($generator->valid() === false) {
+                $rows = $rows->makeLast();
+            }
+
             foreach ($this->elements as $element) {
                 $rows = $element->process($rows);
             }
+
+            $index++;
         }
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Rows::isLast()</li>
    <li>Rows::isFirst()</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This is going to be really useful for transformers/loaders that will sum/group all rows and only then pass it through. 