### PR TITLE
Revert unintended BC break

### DIFF
--- a/src/Flow/ETL/Row.php
+++ b/src/Flow/ETL/Row.php
@@ -94,7 +94,7 @@ final class Row implements Serializable
         );
     }
 
-    public function remove_entries(string ...$names) : self
+    public function remove(string ...$names) : self
     {
         $namesToRemove = [];
 
@@ -107,7 +107,7 @@ final class Row implements Serializable
         return new self($this->entries->remove(...$namesToRemove));
     }
 
-    public function rename_entry(string $currentName, string $newName) : self
+    public function rename(string $currentName, string $newName) : self
     {
         return new self($this->entries->rename($currentName, $newName));
     }

--- a/src/Flow/ETL/Transformer/KeepEntriesTransformer.php
+++ b/src/Flow/ETL/Transformer/KeepEntriesTransformer.php
@@ -51,7 +51,7 @@ final class KeepEntriesTransformer implements Transformer
             $allEntries = $row->entries()->map(fn (Entry $entry) : string => $entry->name());
             $removeEntries = \array_diff($allEntries, $this->names);
 
-            return $row->remove_entries(...$removeEntries);
+            return $row->remove(...$removeEntries);
         });
     }
 }

--- a/src/Flow/ETL/Transformer/RemoveEntriesTransformer.php
+++ b/src/Flow/ETL/Transformer/RemoveEntriesTransformer.php
@@ -49,7 +49,7 @@ final class RemoveEntriesTransformer implements Transformer
          * @psalm-var pure-callable(Row $row) : Row $transformer
          */
         $transformer = function (Row $row) : Row {
-            return $row->remove_entries(...$this->names);
+            return $row->remove(...$this->names);
         };
 
         return $rows->map($transformer);

--- a/src/Flow/ETL/Transformer/RenameEntriesTransformer.php
+++ b/src/Flow/ETL/Transformer/RenameEntriesTransformer.php
@@ -47,7 +47,7 @@ final class RenameEntriesTransformer implements Transformer
     {
         foreach ($this->entryRenames as $entryRename) {
             $rows = $rows->map(function (Row $row) use ($entryRename) : Row {
-                return $row->rename_entry($entryRename->from(), $entryRename->to());
+                return $row->rename($entryRename->from(), $entryRename->to());
             });
         }
 

--- a/tests/Flow/ETL/Tests/Unit/ETLTest.php
+++ b/tests/Flow/ETL/Tests/Unit/ETLTest.php
@@ -615,7 +615,7 @@ ASCIITABLE,
                 new class implements Transformer {
                     public function transform(Rows $rows) : Rows
                     {
-                        return $rows->map(fn (Row $row) => $row->rename_entry('id', 'new_id'));
+                        return $rows->map(fn (Row $row) => $row->rename('id', 'new_id'));
                     }
 
                     public function __serialize() : array
@@ -677,7 +677,7 @@ ASCIITABLE,
                 new class implements Transformer {
                     public function transform(Rows $rows) : Rows
                     {
-                        return $rows->map(fn (Row $row) => $row->rename_entry('id', 'new_id'));
+                        return $rows->map(fn (Row $row) => $row->rename('id', 'new_id'));
                     }
 
                     public function __serialize() : array

--- a/tests/Flow/ETL/Tests/Unit/RowTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowTest.php
@@ -65,7 +65,7 @@ final class RowTest extends TestCase
             new StringEntry('name', 'just a string'),
             new BooleanEntry('active', true)
         );
-        $newRow = $row->rename_entry('name', 'new-name');
+        $newRow = $row->rename('name', 'new-name');
 
         $this->assertEquals(
             Row::create(

--- a/tests/Flow/ETL/Tests/Unit/Transformer/CallbackRowTransformerTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Transformer/CallbackRowTransformerTest.php
@@ -16,7 +16,7 @@ class CallbackRowTransformerTest extends TestCase
     public function test_replacing_dashes_in_entry_name_with_str_replace_callback() : void
     {
         $callbackTransformer = Transform::callback_row(
-            fn (Row $row) : Row => $row->remove_entries('old-int')
+            fn (Row $row) : Row => $row->remove('old-int')
         );
 
         $rows = $callbackTransformer->transform(
@@ -38,7 +38,7 @@ class CallbackRowTransformerTest extends TestCase
     public function test_replacing_dashes_in_entry_name_with_str_replace_callback_with_serialization() : void
     {
         $callbackTransformer = Transform::callback_row(
-            fn (Row $row) : Row => $row->remove_entries('old-int')
+            fn (Row $row) : Row => $row->remove('old-int')
         );
 
         $serialization = new NativePHPSerializer();


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Accidental BC Break in Row class</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->