### PR TITLE
Added callback to run method

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,11 @@ Please read [tests](tests/Flow/ETL/Tests/Unit/Extractor) to find examples of usa
 
 * [buffer](src/Flow/ETL/Extractor/BufferExtractor.php) - [tests](tests/Flow/ETL/Tests/Unit/Extractor/BufferExtractorTest.php)
 * [cache](src/Flow/ETL/Extractor/CacheExtractor.php) - [tests](tests/Flow/ETL/Tests/Unit/Extractor/CacheExtractorTest.php)
-* [process](src/Flow/ETL/Extractor/ProcessExtractor.php) - [tests](tests/Flow/ETL/Tests/Unit/Extractor/ProcessExtractorTest.php)
+* [chain](src/Flow/ETL/Extractor/ChainExtractor.php) - [tests](tests/Flow/ETL/Tests/Unit/Extractor/ChainExtractorTest.php)
+* [chunk](src/Flow/ETL/Extractor/ChunkExtractor.php) - [tests](tests/Flow/ETL/Tests/Unit/Extractor/ChunkExtractorTest.php)  
 * [memory](src/Flow/ETL/Extractor/MemoryExtractor.php) - [tests](tests/Flow/ETL/Tests/Unit/Extractor/MemoryExtractorTest.php)
+* [pipeline](src/Flow/ETL/Extractor/PipelineExtractor.php) - [tests](tests/Flow/ETL/Tests/Unit/Extractor/PipelineExtractorTest.php)  
+* [process](src/Flow/ETL/Extractor/ProcessExtractor.php) - [tests](tests/Flow/ETL/Tests/Unit/Extractor/ProcessExtractorTest.php)
 
 ## Transformers
 

--- a/src/Flow/ETL/DSL/From.php
+++ b/src/Flow/ETL/DSL/From.php
@@ -10,6 +10,7 @@ use Flow\ETL\Extractor\MemoryExtractor;
 use Flow\ETL\Extractor\ProcessExtractor;
 use Flow\ETL\Memory\ArrayMemory;
 use Flow\ETL\Memory\Memory;
+use Flow\ETL\Pipeline;
 use Flow\ETL\Rows;
 
 class From
@@ -45,9 +46,19 @@ class From
         return new Extractor\ChainExtractor(...$extractors);
     }
 
+    final public static function chunks_from(Extractor $extractor, int $chunkSize) : Extractor
+    {
+        return new Extractor\ChunkExtractor($extractor, $chunkSize);
+    }
+
     final public static function memory(Memory $memory, int $chunkSize = 100, string $rowEntryName = 'row') : Extractor
     {
         return new MemoryExtractor($memory, $chunkSize, $rowEntryName);
+    }
+
+    final public static function pipeline(Pipeline $pipeline, ?int $limit = null) : Extractor
+    {
+        return new Extractor\PipelineExtractor($pipeline, $limit);
     }
 
     /**

--- a/src/Flow/ETL/Extractor/ChunkExtractor.php
+++ b/src/Flow/ETL/Extractor/ChunkExtractor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Extractor;
+
+use Flow\ETL\Extractor;
+
+/**
+ * @psalm-immutable
+ */
+final class ChunkExtractor implements Extractor
+{
+    private int $chunkSize;
+
+    private Extractor $extractor;
+
+    public function __construct(Extractor $extractor, int $chunkSize)
+    {
+        $this->extractor = $extractor;
+        $this->chunkSize = $chunkSize;
+    }
+
+    public function extract() : \Generator
+    {
+        foreach ($this->extractor->extract() as $rows) {
+            foreach ($rows->chunks($this->chunkSize) as $rowsChunk) {
+                yield $rowsChunk;
+            }
+        }
+    }
+}

--- a/src/Flow/ETL/Extractor/PipelineExtractor.php
+++ b/src/Flow/ETL/Extractor/PipelineExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Extractor;
+
+use Flow\ETL\Extractor;
+use Flow\ETL\Pipeline;
+use Flow\ETL\Rows;
+
+/**
+ * @psalm-immutable
+ */
+final class PipelineExtractor implements Extractor
+{
+    private ?int $limit;
+
+    /**
+     * @var Pipeline
+     */
+    private Pipeline $pipeline;
+
+    public function __construct(Pipeline $pipeline, ?int $limit = null)
+    {
+        $this->pipeline = $pipeline;
+        $this->limit = $limit;
+    }
+
+    /**
+     * @return \Generator<int, Rows, mixed, void>
+     */
+    public function extract() : \Generator
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        return $this->pipeline->process($this->limit);
+    }
+}

--- a/src/Flow/ETL/Pipeline.php
+++ b/src/Flow/ETL/Pipeline.php
@@ -21,8 +21,11 @@ interface Pipeline
     public function onError(ErrorHandler $errorHandler) : void;
 
     /**
-     * @param \Generator<int, Rows, mixed, void> $generator
      * @param callable(Rows $rows) : void $callback
+     *
+     * @return \Generator<int, Rows, mixed, void>
      */
-    public function process(\Generator $generator, ?int $limit = null, callable $callback = null) : void;
+    public function process(?int $limit = null, callable $callback = null) : \Generator;
+
+    public function source(Extractor $extractor) : void;
 }

--- a/src/Flow/ETL/Pipeline/CollectingPipeline.php
+++ b/src/Flow/ETL/Pipeline/CollectingPipeline.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Pipeline;
 
+use Flow\ETL\DSL\From;
 use Flow\ETL\ErrorHandler;
 use Flow\ETL\Extractor;
 use Flow\ETL\Pipeline;
@@ -41,7 +42,7 @@ final class CollectingPipeline implements Pipeline
 
     public function process(?int $limit = null, callable $callback = null) : \Generator
     {
-        $this->nextPipeline->source(new Extractor\ProcessExtractor(
+        $this->nextPipeline->source(From::rows(
             (new Rows())->merge(...\iterator_to_array($this->pipeline->process($limit)))
         ));
 

--- a/src/Flow/ETL/Pipeline/CollectingPipeline.php
+++ b/src/Flow/ETL/Pipeline/CollectingPipeline.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Pipeline;
 
 use Flow\ETL\ErrorHandler;
+use Flow\ETL\Extractor;
 use Flow\ETL\Pipeline;
 use Flow\ETL\Rows;
 
@@ -38,28 +39,17 @@ final class CollectingPipeline implements Pipeline
         $this->nextPipeline->onError($errorHandler);
     }
 
-    public function process(\Generator $generator, ?int $limit = null, callable $callback = null) : void
+    public function process(?int $limit = null, callable $callback = null) : \Generator
     {
-        $rows = [];
+        $this->nextPipeline->source(new Extractor\ProcessExtractor(
+            (new Rows())->merge(...\iterator_to_array($this->pipeline->process($limit)))
+        ));
 
-        while ($generator->valid()) {
-            $this->pipeline->process($generator, $limit, function (Rows $nextRows) use (&$rows) : void {
-                /** @psalm-suppress MixedArrayAssignment */
-                $rows[] = $nextRows;
-            });
-        }
-
-        /** @var array<Rows> $rows */
-        $mergedRows = (new Rows())->merge(...$rows);
-
-        $this->nextPipeline->process($this->generate($mergedRows), $limit, $callback);
+        return $this->nextPipeline->process($limit, $callback);
     }
 
-    /**
-     * @return \Generator<int, Rows, mixed, void>
-     */
-    private function generate(Rows $rows) : \Generator
+    public function source(Extractor $extractor) : void
     {
-        yield $rows;
+        $this->pipeline->source($extractor);
     }
 }

--- a/src/Flow/ETL/Pipeline/ParallelizingPipeline.php
+++ b/src/Flow/ETL/Pipeline/ParallelizingPipeline.php
@@ -6,8 +6,9 @@ namespace Flow\ETL\Pipeline;
 
 use Flow\ETL\ErrorHandler;
 use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Extractor;
+use Flow\ETL\Extractor\PipelineExtractor;
 use Flow\ETL\Pipeline;
-use Flow\ETL\Rows;
 
 /**
  * @internal
@@ -46,20 +47,20 @@ final class ParallelizingPipeline implements Pipeline
         $this->nextPipeline->onError($errorHandler);
     }
 
-    public function process(\Generator $generator, ?int $limit = null, callable $callback = null) : void
+    public function process(?int $limit = null, callable $callback = null) : \Generator
     {
-        $this->pipeline->process($generator, $limit, function (Rows $rows) use ($limit, $callback) : void {
-            foreach ($rows->chunks($this->parallel) as $chunk) {
-                $this->nextPipeline->process($this->generate($chunk), $limit, $callback);
-            }
-        });
+        $this->nextPipeline->source(
+            new Extractor\ChunkExtractor(
+                new PipelineExtractor($this->pipeline, $limit),
+                $this->parallel
+            )
+        );
+
+        return $this->nextPipeline->process($limit, $callback);
     }
 
-    /**
-     * @return \Generator<int, Rows, mixed, void>
-     */
-    private function generate(Rows $rows) : \Generator
+    public function source(Extractor $extractor) : void
     {
-        yield $rows;
+        $this->pipeline->source($extractor);
     }
 }

--- a/src/Flow/ETL/Pipeline/ParallelizingPipeline.php
+++ b/src/Flow/ETL/Pipeline/ParallelizingPipeline.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Pipeline;
 
+use Flow\ETL\DSL\From;
 use Flow\ETL\ErrorHandler;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Extractor;
-use Flow\ETL\Extractor\PipelineExtractor;
 use Flow\ETL\Pipeline;
 
 /**
@@ -50,8 +50,8 @@ final class ParallelizingPipeline implements Pipeline
     public function process(?int $limit = null, callable $callback = null) : \Generator
     {
         $this->nextPipeline->source(
-            new Extractor\ChunkExtractor(
-                new PipelineExtractor($this->pipeline, $limit),
+            From::chunks_from(
+                From::pipeline($this->pipeline, $limit),
                 $this->parallel
             )
         );

--- a/src/Flow/ETL/Pipeline/SynchronousPipeline.php
+++ b/src/Flow/ETL/Pipeline/SynchronousPipeline.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Pipeline;
 
+use Flow\ETL\DSL\From;
 use Flow\ETL\ErrorHandler;
 use Flow\ETL\ErrorHandler\ThrowError;
 use Flow\ETL\Extractor;
@@ -27,7 +28,7 @@ final class SynchronousPipeline implements Pipeline
     {
         $this->errorHandler = new ThrowError();
         $this->pipes = Pipes::empty();
-        $this->extractor = new Extractor\ProcessExtractor(new Rows());
+        $this->extractor = From::rows(new Rows());
     }
 
     public function add(Pipe $pipe) : void

--- a/tests/Flow/ETL/Tests/Unit/Extractor/ChunkExtractorTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Extractor/ChunkExtractorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Extractor;
+
+use Flow\ETL\Extractor\ChunkExtractor;
+use Flow\ETL\Tests\Double\AllRowTypesFakeExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class ChunkExtractorTest extends TestCase
+{
+    public function test_chunk_extractor() : void
+    {
+        $extractor = new ChunkExtractor(new AllRowTypesFakeExtractor($batches = 5, $rowsNumber = 20), $chunkSize = 10);
+
+        $this->assertCount(
+            $rowsNumber / $chunkSize * $batches,
+            \iterator_to_array($extractor->extract())
+        );
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Extractor/PipelineExtractorTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Extractor/PipelineExtractorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Extractor;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Extractor\PipelineExtractor;
+use Flow\ETL\Extractor\ProcessExtractor;
+use Flow\ETL\Pipeline\SynchronousPipeline;
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use PHPUnit\Framework\TestCase;
+
+final class PipelineExtractorTest extends TestCase
+{
+    public function test_pipeline_extractor() : void
+    {
+        $pipeline = new SynchronousPipeline();
+        $pipeline->source(new ProcessExtractor(
+            new Rows(Row::create(Entry::integer('id', 1)), Row::create(Entry::integer('id', 2))),
+            new Rows(Row::create(Entry::integer('id', 3)), Row::create(Entry::integer('id', 4))),
+            new Rows(Row::create(Entry::integer('id', 5)), Row::create(Entry::integer('id', 6))),
+        ));
+
+        $extractor = new PipelineExtractor($pipeline);
+
+        $this->assertCount(
+            3,
+            \iterator_to_array($extractor->extract())
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>PipelineExtractor</li>
    <li>ChunkExtractor</li>
    <li>ETL::forEach alias method for ETL::run</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>ParallelizingPipeline to create one pipeline, instead of creating one for each chunk</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Pipeline process returns Generator</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->