### PR TITLE
Replaced Schema::isValid with SchemaValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Output:
 ## Schema Validation
 
 Before loading data to sink it might be a good idea to validate it against the schema.
-Row Schema needs to come a definition for each entry in Row, definition is created from: 
+Row Schema is built from Entry Definitions, each definition is created from: 
 
 * entry - name of entry
 * type - type of entry (class string)
@@ -486,6 +486,34 @@ ETL::read($from)
           Schema\Definition::string('name', $nullable = true),
           Schema\Definition::boolean('active', $nullable = false),
       )
+  )
+  ->write($to)
+  ->run();
+```
+
+### Schema Validator 
+
+There is more than one way to validate the schema, built in strategies are defined below: 
+
+* [StrictValidator](src/Flow/ETL/Row/Schema/StrictValidator.php) - each row must exactly match the schema, extra entries will fail validation
+* [SelectiveValidator](src/Flow/ETL/Row/Schema/SelectiveValidator.php) - only rows defined in the schema must match, any extra entry in row will be ignored 
+
+By default, ETL is initializing `StrictValidator`, but it's possible to override it by passing second argument to `ETL::validate()` method.
+
+Example: 
+
+```php 
+<?php
+
+ETL::read($from)
+  ->rows($transform)
+  ->validate(
+      new Schema(
+          Schema\Definition::integer('id', $nullable = false),
+          Schema\Definition::string('name', $nullable = true),
+          Schema\Definition::boolean('active', $nullable = false),
+      ),
+      new SelectiveValidator()
   )
   ->write($to)
   ->run();

--- a/src/Flow/ETL/ETL.php
+++ b/src/Flow/ETL/ETL.php
@@ -239,9 +239,15 @@ final class ETL
         return $this;
     }
 
-    public function validate(Schema $schema) : self
+    /**
+     * @param Schema $schema
+     * @param null|SchemaValidator $validator - when null, StrictValidator gets initialized
+     *
+     * @return $this
+     */
+    public function validate(Schema $schema, SchemaValidator $validator = null) : self
     {
-        $this->pipeline->add(new SchemaValidationLoader($schema));
+        $this->pipeline->add(new SchemaValidationLoader($schema, $validator ?? new Schema\StrictValidator()));
 
         return $this;
     }

--- a/src/Flow/ETL/Exception/SchemaValidationException.php
+++ b/src/Flow/ETL/Exception/SchemaValidationException.php
@@ -4,35 +4,26 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Exception;
 
-use Flow\ETL\Row;
 use Flow\ETL\Row\Schema;
+use Flow\ETL\Rows;
 
 final class SchemaValidationException extends RuntimeException
 {
-    /**
-     * @var Row
-     */
-    private Row $row;
+    private Rows $rows;
 
-    /**
-     * @var Schema
-     */
     private Schema $schema;
 
-    public function __construct(Schema $schema, Row $row)
+    public function __construct(Schema $schema, Rows $rows)
     {
         $this->schema = $schema;
-        $this->row = $row;
+        $this->rows = $rows;
 
         parent::__construct('Row does not match schema.');
     }
 
-    /**
-     * @return Row
-     */
-    public function row() : Row
+    public function rows() : Rows
     {
-        return $this->row;
+        return $this->rows;
     }
 
     /**

--- a/src/Flow/ETL/Row/Entries.php
+++ b/src/Flow/ETL/Row/Entries.php
@@ -109,7 +109,7 @@ final class Entries implements \ArrayAccess, \Countable, \IteratorAggregate, Ser
     }
 
     /**
-     * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     public function get(string $name) : Entry
     {

--- a/src/Flow/ETL/Row/Schema.php
+++ b/src/Flow/ETL/Row/Schema.php
@@ -4,24 +4,35 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row;
 
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Schema\Definition;
 use Flow\Serializer\Serializable;
 
-final class Schema implements Serializable
+final class Schema implements \Countable, Serializable
 {
     /**
-     * @var array<Definition>
+     * @var array<string, Definition>
      */
     private array $definitions;
 
     public function __construct(Definition ...$definitions)
     {
-        $this->definitions = $definitions;
+        $uniqueDefinitions = [];
+
+        foreach ($definitions as $definition) {
+            $uniqueDefinitions[$definition->entry()] = $definition;
+        }
+
+        if (\count($uniqueDefinitions) !== \count($definitions)) {
+            throw new InvalidArgumentException(\sprintf('Entry definitions must be unique, given: [%s]', \implode(', ', \array_map(fn (Definition $d) => $d->entry(), $definitions))));
+        }
+
+        $this->definitions = $uniqueDefinitions;
     }
 
     /**
-     * @return array{definitions: array<Definition>}
+     * @return array{definitions: array<string, Definition>}
      */
     public function __serialize() : array
     {
@@ -33,11 +44,42 @@ final class Schema implements Serializable
     /**
      * @psalm-suppress MoreSpecificImplementedParamType
      *
-     * @param array{definitions: array<Definition>} $data
+     * @param array{definitions: array<string, Definition>} $data
      */
     public function __unserialize(array $data) : void
     {
         $this->definitions = $data['definitions'];
+    }
+
+    public function count() : int
+    {
+        return \count($this->definitions);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function entries() : array
+    {
+        return \array_keys($this->definitions);
+    }
+
+    public function findDefinition(string $entry) : ?Definition
+    {
+        if (!\array_key_exists($entry, $this->definitions)) {
+            return null;
+        }
+
+        return $this->definitions[$entry];
+    }
+
+    public function getDefinition(string $entry) : ?Definition
+    {
+        if (!\array_key_exists($entry, $this->definitions)) {
+            throw new InvalidArgumentException("There is no definition for \"{$entry}\" in the schema.");
+        }
+
+        return $this->definitions[$entry];
     }
 
     public function isValid(Row $row) : bool

--- a/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/Flow/ETL/Row/Schema/Definition.php
@@ -114,6 +114,11 @@ final class Definition implements Serializable
         $this->nullable = $data['nullable'];
         $this->constraint = $data['constraint'];
     }
+
+    public function entry() : string
+    {
+        return \mb_strtolower($this->entry);
+    }
     // @codeCoverageIgnoreEnd
 
     public function matches(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Schema/SelectiveValidator.php
+++ b/src/Flow/ETL/Row/Schema/SelectiveValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Schema;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Row;
+use Flow\ETL\Row\Schema;
+use Flow\ETL\Rows;
+use Flow\ETL\SchemaValidator;
+
+/**
+ * Matches only entries defined in the schema, ignoring every other entries in the row.
+ */
+final class SelectiveValidator implements SchemaValidator
+{
+    /**
+     * @phpstan-ignore-next-line
+     *
+     * @return array
+     * @psalm-suppress LessSpecificImplementedReturnType
+     */
+    public function __serialize() : array
+    {
+        return [];
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     *
+     * @param array $data
+     */
+    public function __unserialize(array $data) : void
+    {
+    }
+
+    public function isValid(Rows $rows, Schema $schema) : bool
+    {
+        foreach ($schema->entries() as $entryName) {
+            /** @var Definition $definition */
+            $definition = $schema->getDefinition($entryName);
+
+            foreach ($rows as $row) {
+                try {
+                    $entry = $row->entries()->get($entryName);
+
+                    if (!$definition->matches($entry)) {
+                        return false;
+                    }
+                } catch (InvalidArgumentException $e) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Flow/ETL/Row/Schema/StrictValidator.php
+++ b/src/Flow/ETL/Row/Schema/StrictValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Schema;
+
+use Flow\ETL\Row\Schema;
+use Flow\ETL\Rows;
+use Flow\ETL\SchemaValidator;
+use Flow\Serializer\Serializable;
+
+/**
+ * Matches all entries in the schema, if row comes with any extra entry it will fail validation.
+ */
+final class StrictValidator implements SchemaValidator, Serializable
+{
+    /**
+     * @phpstan-ignore-next-line
+     *
+     * @return array
+     * @psalm-suppress LessSpecificImplementedReturnType
+     */
+    public function __serialize() : array
+    {
+        return [];
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     *
+     * @param array $data
+     */
+    public function __unserialize(array $data) : void
+    {
+    }
+
+    public function isValid(Rows $rows, Schema $schema) : bool
+    {
+        foreach ($rows as $row) {
+            if ($schema->count() !== $row->entries()->count()) {
+                return false;
+            }
+
+            foreach ($row->entries()->all() as $entry) {
+                $definition = $schema->findDefinition($entry->name());
+
+                if ($definition === null) {
+                    return false;
+                }
+
+                if (!$definition->matches($entry)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Flow/ETL/SchemaValidator.php
+++ b/src/Flow/ETL/SchemaValidator.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL;
+
+use Flow\ETL\Row\Schema;
+
+interface SchemaValidator
+{
+    public function isValid(Rows $rows, Schema $schema) : bool;
+}

--- a/tests/Flow/ETL/Tests/Unit/ETLTest.php
+++ b/tests/Flow/ETL/Tests/Unit/ETLTest.php
@@ -754,7 +754,30 @@ ASCIITABLE,
             ->limit(-1);
     }
 
-    public function test_validation_against_schema() : void
+    public function test_selective_validation_against_schema() : void
+    {
+        $rows = ETL::process(
+            new Rows(
+                Row::create(Entry::integer('id', 1), Entry::string('name', 'foo'), Entry::boolean('active', true)),
+                Row::create(Entry::integer('id', 2), Entry::null('name'), Entry::array('tags', ['foo', 'bar'])),
+                Row::create(Entry::integer('id', 2), Entry::string('name', 'bar'), Entry::boolean('active', false)),
+            )
+        )->validate(
+            new Schema(Schema\Definition::integer('id', $nullable = false)),
+            new Schema\SelectiveValidator()
+        )->fetch();
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(Entry::integer('id', 1), Entry::string('name', 'foo'), Entry::boolean('active', true)),
+                Row::create(Entry::integer('id', 2), Entry::null('name'), Entry::array('tags', ['foo', 'bar'])),
+                Row::create(Entry::integer('id', 2), Entry::string('name', 'bar'), Entry::boolean('active', false)),
+            ),
+            $rows
+        );
+    }
+
+    public function test_strict_validation_against_schema() : void
     {
         $rows = ETL::process(
             new Rows(

--- a/tests/Flow/ETL/Tests/Unit/Loader/SchemaValidationLoaderTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Loader/SchemaValidationLoaderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Loader;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Exception\SchemaValidationException;
+use Flow\ETL\Loader\SchemaValidationLoader;
+use Flow\ETL\Row;
+use Flow\ETL\Row\Schema;
+use Flow\ETL\Rows;
+use PHPUnit\Framework\TestCase;
+
+final class SchemaValidationLoaderTest extends TestCase
+{
+    public function test_schema_validation_failed() : void
+    {
+        $this->expectException(SchemaValidationException::class);
+
+        $loader = new SchemaValidationLoader(
+            new Schema(
+                Schema\Definition::integer('id')
+            ),
+            new Schema\StrictValidator()
+        );
+
+        $loader->load(new Rows(
+            Row::create(Entry::string('id', '1'))
+        ));
+    }
+
+    public function test_schema_validation_succeed() : void
+    {
+        $loader = new SchemaValidationLoader(
+            new Schema(
+                Schema\Definition::integer('id')
+            ),
+            new Schema\StrictValidator()
+        );
+
+        $loader->load(new Rows(
+            Row::create(Entry::integer('id', 1))
+        ));
+
+        // validate that error wasn't thrown
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Schema;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Row;
+use Flow\ETL\Row\Schema;
+use Flow\ETL\Row\Schema\SelectiveValidator;
+use Flow\ETL\Rows;
+use PHPUnit\Framework\TestCase;
+
+final class SelectiveValidatorTest extends TestCase
+{
+    public function test_rows_with_a_missing_entry() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name'),
+        );
+
+        $this->assertFalse(
+            (new SelectiveValidator())->isValid(
+                new Rows(Row::create(Entry::integer('id', 1), Entry::boolean('active', true))),
+                $schema
+            )
+        );
+    }
+
+    public function test_rows_with_an_extra_entry() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name'),
+        );
+
+        $this->assertTrue(
+            (new SelectiveValidator())->isValid(
+                new Rows(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true))),
+                $schema
+            )
+        );
+    }
+
+    public function test_rows_with_single_invalid_entry() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::boolean('name'),
+            Schema\Definition::boolean('active'),
+        );
+
+        $this->assertFalse(
+            (new SelectiveValidator())->isValid(
+                new Rows(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true))),
+                $schema
+            )
+        );
+    }
+
+    public function test_rows_with_single_invalid_row() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::string('name'),
+            Schema\Definition::boolean('active'),
+        );
+
+        $this->assertFalse(
+            (new SelectiveValidator())->isValid(
+                new Rows(
+                    Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true)),
+                    Row::create(Entry::integer('id', 1), Entry::boolean('active', true))
+                ),
+                $schema
+            )
+        );
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Schema;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Row;
+use Flow\ETL\Row\Schema;
+use Flow\ETL\Row\Schema\StrictValidator;
+use Flow\ETL\Rows;
+use PHPUnit\Framework\TestCase;
+
+final class StrictValidatorTest extends TestCase
+{
+    public function test_rows_with_a_missing_entry() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name'),
+        );
+
+        $this->assertFalse(
+            (new StrictValidator())->isValid(
+                new Rows(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true))),
+                $schema
+            )
+        );
+    }
+
+    public function test_rows_with_all_entries_valid() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name'),
+            Schema\Definition::boolean('active'),
+        );
+
+        $this->assertTrue(
+            (new StrictValidator())->isValid(
+                new Rows(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true))),
+                $schema
+            )
+        );
+    }
+
+    public function test_rows_with_an_extra_entry() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name'),
+            Schema\Definition::boolean('active'),
+            Schema\Definition::array('tags'),
+        );
+
+        $this->assertFalse(
+            (new StrictValidator())->isValid(
+                new Rows(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true))),
+                $schema
+            )
+        );
+    }
+
+    public function test_rows_with_single_invalid_entry() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::boolean('name'),
+            Schema\Definition::boolean('active'),
+        );
+
+        $this->assertFalse(
+            (new StrictValidator())->isValid(
+                new Rows(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true))),
+                $schema
+            )
+        );
+    }
+
+    public function test_rows_with_single_invalid_row() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name'),
+            Schema\Definition::boolean('active'),
+        );
+
+        $this->assertFalse(
+            (new StrictValidator())->isValid(
+                new Rows(
+                    Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true)),
+                    Row::create(Entry::integer('id', 1), Entry::boolean('active', true))
+                ),
+                $schema
+            )
+        );
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
@@ -4,62 +4,29 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Row;
 
-use Flow\ETL\DSL\Entry;
-use Flow\ETL\Row;
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Schema;
 use PHPUnit\Framework\TestCase;
 
 final class SchemaTest extends TestCase
 {
-    public function test_row_with_a_missing_entry() : void
+    public function test_allowing_only_unique_defintions() : void
     {
-        $schema = new Schema(
-            Schema\Definition::integer('id'),
-            Schema\Definition::string('name'),
-        );
+        $this->expectException(InvalidArgumentException::class);
 
-        $this->assertFalse(
-            $schema->isValid(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true)))
+        new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('id')
         );
     }
 
-    public function test_row_with_all_entries_valid() : void
+    public function test_allowing_only_unique_defintions_case_insensitive() : void
     {
-        $schema = new Schema(
+        $this->expectException(InvalidArgumentException::class);
+
+        new Schema(
             Schema\Definition::integer('id'),
-            Schema\Definition::string('name'),
-            Schema\Definition::boolean('active'),
-        );
-
-        $this->assertTrue(
-            $schema->isValid(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true)))
-        );
-    }
-
-    public function test_row_with_an_extra_entry() : void
-    {
-        $schema = new Schema(
-            Schema\Definition::integer('id'),
-            Schema\Definition::string('name'),
-            Schema\Definition::boolean('active'),
-            Schema\Definition::array('tags'),
-        );
-
-        $this->assertFalse(
-            $schema->isValid(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true)))
-        );
-    }
-
-    public function test_row_with_single_invalid_entry() : void
-    {
-        $schema = new Schema(
-            Schema\Definition::integer('id'),
-            Schema\Definition::boolean('name'),
-            Schema\Definition::boolean('active'),
-        );
-
-        $this->assertFalse(
-            $schema->isValid(Row::create(Entry::integer('id', 1), Entry::string('name', 'test'), Entry::boolean('active', true)))
+            Schema\Definition::integer('Id')
         );
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Replaced Schema::isValid with SchemaValidator</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This will make schema validation a bit more flexible, it's also making the validation and extension point of the ETL. 

The use case is following: 
Sometimes you just need to make sure that one from multiple entries follows the schema. Especially when it comes to validation against constraints. (to make sure that entry is given type and value is one of the defined at list)