### PR TITLE
Renamed find into findOne and added new find method to Rows

### DIFF
--- a/src/Flow/ETL/Rows.php
+++ b/src/Flow/ETL/Rows.php
@@ -194,7 +194,29 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate, Serial
     /**
      * @psalm-param pure-callable(Row) : bool $callable
      */
-    public function find(callable $callable) : ?Row
+    public function find(callable $callable) : self
+    {
+        $rows = $this->rows;
+
+        if (!\count($rows)) {
+            return new self();
+        }
+
+        $rows = [];
+
+        foreach ($this->rows as $row) {
+            if ($callable($row)) {
+                $rows[] = $row;
+            }
+        }
+
+        return new self(...$rows);
+    }
+
+    /**
+     * @psalm-param pure-callable(Row) : bool $callable
+     */
+    public function findOne(callable $callable) : ?Row
     {
         $rows = $this->rows;
 
@@ -202,16 +224,16 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate, Serial
             return null;
         }
 
-        $results = [];
+        $rows = [];
 
         foreach ($this->rows as $row) {
             if ($callable($row)) {
-                $results[] = $row;
+                $rows[] = $row;
             }
         }
 
-        if (\count($results)) {
-            return \current($results);
+        if (\count($rows)) {
+            return \current($rows);
         }
 
         return null;

--- a/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -288,18 +288,42 @@ final class RowsTest extends TestCase
         $rows = new Rows(
             $one   = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
             $two   = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
+            $three = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'one')),
+            $four  = Row::create(new IntegerEntry('number', 4), new StringEntry('name', 'four')),
+            $three1 = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
+        );
+
+        $this->assertEquals(
+            new Rows(
+                $one,
+                $three
+            ),
+            $rows->find(fn (Row $row) : bool => $row->valueOf('name') === 'one')
+        );
+    }
+
+    public function test_find_on_empty_rows() : void
+    {
+        $this->assertEquals(new Rows(), (new Rows())->find(fn (Row $row) => false));
+    }
+
+    public function test_find_one() : void
+    {
+        $rows = new Rows(
+            $one   = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
+            $two   = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
             $three = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
             $four  = Row::create(new IntegerEntry('number', 4), new StringEntry('name', 'four')),
             $three1 = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
         );
 
-        $this->assertSame($three, $rows->find(fn (Row $row) : bool => $row->valueOf('number') === 3));
-        $this->assertNotSame($three1, $rows->find(fn (Row $row) : bool => $row->valueOf('number') === 3));
+        $this->assertSame($three, $rows->findOne(fn (Row $row) : bool => $row->valueOf('number') === 3));
+        $this->assertNotSame($three1, $rows->findOne(fn (Row $row) : bool => $row->valueOf('number') === 3));
     }
 
-    public function test_find_on_empty_rows() : void
+    public function test_find_one_on_empty_rows() : void
     {
-        $this->asserTNull((new Rows())->find(fn (Row $row) => false));
+        $this->assertNull((new Rows())->findOne(fn (Row $row) => false));
     }
 
     public function test_find_without_results() : void
@@ -312,7 +336,7 @@ final class RowsTest extends TestCase
             $three1 = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
         );
 
-        $this->assertNull($rows->find(fn (Row $row) : bool => $row->valueOf('number') === 5));
+        $this->assertNull($rows->findOne(fn (Row $row) : bool => $row->valueOf('number') === 5));
     }
 
     public function test_first_on_empty_rows() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Rows::find() : Rows</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>renamed Rows::find into Rows::findOne</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->