### PR TITLE
Make entry names case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ All entries are available through [DSL\Entry](src/Flow/ETL/DSL/Entry.php)
 * [string](src/Flow/ETL/Row/Entry/StringEntry.php)
 * [structure](src/Flow/ETL/Row/Entry/StructureEntry.php)
 
+> Entry names are case sensitive, `entry` is not the same as `Entry`.
+
 ## Extractors aka Readers
 
 All generic extractors are available through [DSL\From](src/Flow/ETL/DSL/From.php)
@@ -469,6 +471,8 @@ Output:
 ```
 
 ## Schema Validation
+
+> Entry names are case sensitive, `entry` is not the same as `Entry`.
 
 Before loading data to sink it might be a good idea to validate it against the schema.
 Row Schema is built from Entry Definitions, each definition is created from: 

--- a/src/Flow/ETL/Row/Entries.php
+++ b/src/Flow/ETL/Row/Entries.php
@@ -33,7 +33,7 @@ final class Entries implements \ArrayAccess, \Countable, \IteratorAggregate, Ser
 
         if (\count($entries)) {
             foreach ($entries as $entry) {
-                $this->entries[\mb_strtolower($entry->name())] = $entry;
+                $this->entries[$entry->name()] = $entry;
             }
 
             if (\count($this->entries) !== \count($entries)) {
@@ -153,7 +153,7 @@ final class Entries implements \ArrayAccess, \Countable, \IteratorAggregate, Ser
     public function has(string ...$names) : bool
     {
         foreach ($names as $name) {
-            if (!\array_key_exists(\mb_strtolower($name), $this->entries)) {
+            if (!\array_key_exists($name, $this->entries)) {
                 return false;
             }
         }
@@ -351,7 +351,7 @@ final class Entries implements \ArrayAccess, \Countable, \IteratorAggregate, Ser
     private function find(string $name) : ?Entry
     {
         if ($this->has($name)) {
-            return $this->entries[\mb_strtolower($name)];
+            return $this->entries[$name];
         }
 
         return null;

--- a/src/Flow/ETL/Row/Entry/ArrayEntry.php
+++ b/src/Flow/ETL/Row/Entry/ArrayEntry.php
@@ -55,7 +55,7 @@ final class ArrayEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/BooleanEntry.php
+++ b/src/Flow/ETL/Row/Entry/BooleanEntry.php
@@ -74,7 +74,7 @@ final class BooleanEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/CollectionEntry.php
+++ b/src/Flow/ETL/Row/Entry/CollectionEntry.php
@@ -56,7 +56,7 @@ final class CollectionEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($name) === \mb_strtolower($name);
+        return $name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/DateTimeEntry.php
+++ b/src/Flow/ETL/Row/Entry/DateTimeEntry.php
@@ -48,7 +48,7 @@ final class DateTimeEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/FloatEntry.php
+++ b/src/Flow/ETL/Row/Entry/FloatEntry.php
@@ -64,7 +64,7 @@ final class FloatEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/IntegerEntry.php
+++ b/src/Flow/ETL/Row/Entry/IntegerEntry.php
@@ -60,7 +60,7 @@ final class IntegerEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/JsonEntry.php
+++ b/src/Flow/ETL/Row/Entry/JsonEntry.php
@@ -125,7 +125,7 @@ final class JsonEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/NullEntry.php
+++ b/src/Flow/ETL/Row/Entry/NullEntry.php
@@ -44,7 +44,7 @@ final class NullEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/ObjectEntry.php
+++ b/src/Flow/ETL/Row/Entry/ObjectEntry.php
@@ -48,7 +48,7 @@ final class ObjectEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/StringEntry.php
+++ b/src/Flow/ETL/Row/Entry/StringEntry.php
@@ -72,7 +72,7 @@ final class StringEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Entry/StructureEntry.php
+++ b/src/Flow/ETL/Row/Entry/StructureEntry.php
@@ -58,7 +58,7 @@ final class StructureEntry implements Entry
 
     public function is(string $name) : bool
     {
-        return \mb_strtolower($this->name) === \mb_strtolower($name);
+        return $this->name === $name;
     }
 
     public function isEqual(Entry $entry) : bool

--- a/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/Flow/ETL/Row/Schema/Definition.php
@@ -112,7 +112,7 @@ final class Definition implements Serializable
 
     public function entry() : string
     {
-        return \mb_strtolower($this->entry);
+        return $this->entry;
     }
     // @codeCoverageIgnoreEnd
 

--- a/tests/Flow/ETL/Tests/Unit/Row/EntriesTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/EntriesTest.php
@@ -120,14 +120,24 @@ final class EntriesTest extends TestCase
         $entries->remove('non-existing-entry');
     }
 
-    public function test_case_insensitive_entry_names() : void
+    public function test_case_sensitive_entry_names() : void
     {
         $entries = new Entries(
             new StringEntry('entry-Name', 'just a string'),
         );
 
-        $this->assertTrue($entries->has('entry-name'));
-        $this->assertEquals(new StringEntry('entry-Name', 'just a string'), $entries->get('entry-name'));
+        $this->assertFalse($entries->has('entry-name'));
+    }
+
+    public function test_create_from_non_unique_entries() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Entry names must be unique, given: [integer-entry, integer-entry]');
+
+        new Entries(
+            new IntegerEntry('integer-entry', 100),
+            new IntegerEntry('integer-entry', 200)
+        );
     }
 
     public function test_get_all_entries() : void
@@ -186,6 +196,16 @@ final class EntriesTest extends TestCase
         $entries1->merge($entries2);
     }
 
+    public function test_merge_duplicated_entries_case_insensitive_() : void
+    {
+        $entries1 = new Entries(new StringEntry('string-name', 'new string entry'));
+        $entries2 = new Entries(new StringEntry('string-Name', 'new string entry'));
+
+        $merged = $entries1->merge($entries2);
+
+        $this->assertCount(2, $merged);
+    }
+
     public function test_merge_entries() : void
     {
         $entries1 = new Entries(new StringEntry('string-name', 'new string entry'));
@@ -222,6 +242,17 @@ final class EntriesTest extends TestCase
         $this->expectExceptionMessage('Added entries names must be unique, given: [entry-name] + [entry-name]');
 
         $entries->add(new StringEntry('entry-name', 'just a string'));
+    }
+
+    public function test_prevents_from_adding_entry_with_the_same_name_case_insensitive() : void
+    {
+        $entries = new Entries(
+            new IntegerEntry('entry-Name', 100)
+        );
+
+        $newEntries = $entries->add(new StringEntry('entry-name', 'just a string'));
+
+        $this->assertCount(2, $newEntries);
     }
 
     public function test_prevents_from_creating_collection_with_duplicate_entry_names() : void

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/BooleanEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/BooleanEntryTest.php
@@ -14,7 +14,7 @@ final class BooleanEntryTest extends TestCase
         yield 'equal names and values' => [true, new BooleanEntry('name', true), new BooleanEntry('name', true)];
         yield 'different names and values' => [false, new BooleanEntry('name', true), new BooleanEntry('different_name', true)];
         yield 'equal names and different values' => [false, new BooleanEntry('name', true), new BooleanEntry('name', false)];
-        yield 'different names characters and equal values' => [true, new BooleanEntry('NAME', true), new BooleanEntry('name', true)];
+        yield 'different names characters and equal values' => [false, new BooleanEntry('NAME', true), new BooleanEntry('name', true)];
     }
 
     /**

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/DateTimeEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/DateTimeEntryTest.php
@@ -16,7 +16,7 @@ final class DateTimeEntryTest extends TestCase
         yield 'equal names and different values day' => [false, new DateTimeEntry('name', new \DateTimeImmutable('2020-01-01 00:00:00+00')), new DateTimeEntry('name', new \DateTimeImmutable('2020-01-02 00:00:00+00'))];
         yield 'equal names and different values hour' => [false, new DateTimeEntry('name', new \DateTimeImmutable('2020-01-01 00:00:00+00')), new DateTimeEntry('name', new \DateTimeImmutable('2020-01-01 02:00:00+00'))];
         yield 'equal names and different values tz' => [false, new DateTimeEntry('name', new \DateTimeImmutable('2020-01-01 00:00:00+00')), new DateTimeEntry('name', new \DateTimeImmutable('2020-01-01 00:00:00+10'))];
-        yield 'different names characters and equal values' => [true, new DateTimeEntry('NAME', new \DateTimeImmutable('2020-01-01 00:00:00+00')), new DateTimeEntry('name', new \DateTimeImmutable('2020-01-01 00:00:00+00'))];
+        yield 'different names characters and equal values' => [false, new DateTimeEntry('NAME', new \DateTimeImmutable('2020-01-01 00:00:00+00')), new DateTimeEntry('name', new \DateTimeImmutable('2020-01-01 00:00:00+00'))];
         yield 'equal names and equal values and different format' => [false, new DateTimeEntry('name', new \DateTimeImmutable('2020-02-19 00:00:00+00')), new DateTimeEntry('name', new \DateTimeImmutable('2020-01-02 00:00:00+00'))];
         yield 'equal names and equal values for given format' => [true, new DateTimeEntry('name', new \DateTimeImmutable('2020-02-19 00:00:00+00')), new DateTimeEntry('name', new \DateTimeImmutable('2020-02-19 00:00:00+00'))];
     }

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/FloatEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/FloatEntryTest.php
@@ -22,8 +22,8 @@ final class FloatEntryTest extends TestCase
         yield 'equal names and values' => [true, new FloatEntry('name', 1.0), new FloatEntry('name', 1.0)];
         yield 'different names and values' => [false, new FloatEntry('name', 1.0), new FloatEntry('different_name', 1.0)];
         yield 'equal names and different values' => [false, new FloatEntry('name', 1.0), new FloatEntry('name', 2)];
-        yield 'different names characters and equal values' => [true, new FloatEntry('NAME', 1.1), new FloatEntry('name', 1.1)];
-        yield 'different names characters and equal values with high precision' => [true, new FloatEntry('NAME', 1.00001), new FloatEntry('name', 1.00001)];
+        yield 'different names characters and equal values' => [false, new FloatEntry('NAME', 1.1), new FloatEntry('name', 1.1)];
+        yield 'different names characters and equal values with high precision' => [false, new FloatEntry('NAME', 1.00001), new FloatEntry('name', 1.00001)];
         yield 'different names characters and different values with high precision' => [false, new FloatEntry('NAME', 1.205502), new FloatEntry('name', 1.205501)];
     }
 

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/IntegerEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/IntegerEntryTest.php
@@ -24,7 +24,7 @@ final class IntegerEntryTest extends TestCase
         yield 'equal names and values' => [true, new IntegerEntry('name', 1), new IntegerEntry('name', 1)];
         yield 'different names and values' => [false, new IntegerEntry('name', 1), new IntegerEntry('different_name', 1)];
         yield 'equal names and different values' => [false, new IntegerEntry('name', 1), new IntegerEntry('name', 2)];
-        yield 'different names characters and equal values' => [true, new IntegerEntry('NAME', 1), new IntegerEntry('name', 1)];
+        yield 'different names characters and equal values' => [false, new IntegerEntry('NAME', 1), new IntegerEntry('name', 1)];
     }
 
     /**

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/NullEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/NullEntryTest.php
@@ -12,7 +12,7 @@ final class NullEntryTest extends TestCase
     public function is_equal_data_provider() : \Generator
     {
         yield 'equal names and values' => [true, new NullEntry('name'), new NullEntry('name')];
-        yield 'different names characters and equal values' => [true, new NullEntry('NAME'), new NullEntry('name')];
+        yield 'different names characters and equal values' => [false, new NullEntry('NAME'), new NullEntry('name')];
     }
 
     public function test_entry_name_can_be_zero() : void

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/ObjectEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/ObjectEntryTest.php
@@ -14,7 +14,7 @@ final class ObjectEntryTest extends TestCase
         yield 'equal names and values' => [true, new ObjectEntry('name', $object = new \stdClass()), new ObjectEntry('name', $object)];
         yield 'different names and values' => [false, new ObjectEntry('name', $object = new \stdClass()), new ObjectEntry('different_name', $object)];
         yield 'equal names and different values' => [false, new ObjectEntry('name', new \stdClass()), new ObjectEntry('name', new \ArrayObject())];
-        yield 'different names characters and equal values' => [true, new ObjectEntry('NAME', $object = new \stdClass()), new ObjectEntry('name', $object)];
+        yield 'different names characters and equal values' => [false, new ObjectEntry('NAME', $object = new \stdClass()), new ObjectEntry('name', $object)];
     }
 
     public function test_entry_name_can_be_zero() : void

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/StringEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/StringEntryTest.php
@@ -15,7 +15,7 @@ final class StringEntryTest extends TestCase
         yield 'different names and values' => [false, new StringEntry('name', 'value'), new StringEntry('different_name', 'value')];
         yield 'equal names and different values' => [false, new StringEntry('name', 'value'), new StringEntry('name', 'different_value')];
         yield 'equal names and different value characters' => [false, new StringEntry('name', 'value'), new StringEntry('name', 'VALUE')];
-        yield 'different names characters and equal values' => [true, new StringEntry('NAME', 'value'), new StringEntry('name', 'value')];
+        yield 'different names characters and equal values' => [false, new StringEntry('NAME', 'value'), new StringEntry('name', 'value')];
     }
 
     public function test_creates_datetime_value() : void

--- a/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
@@ -22,11 +22,11 @@ final class SchemaTest extends TestCase
 
     public function test_allowing_only_unique_defintions_case_insensitive() : void
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        new Schema(
+        $schema = new Schema(
             Schema\Definition::integer('id'),
             Schema\Definition::integer('Id')
         );
+
+        $this->assertSame(['id', 'Id'], $schema->entries());
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Make entry names case sensitive</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

The end goal is to not check entry names uniqueness at all and rely on the entry index more than entry name. 