### PR TITLE
Fixed GroupByPipeline execution

### DIFF
--- a/src/Flow/ETL/ETL.php
+++ b/src/Flow/ETL/ETL.php
@@ -90,6 +90,9 @@ final class ETL
 
         $this->groupBy->aggregate(...$aggregations);
 
+        $this->pipeline = new GroupByPipeline($this->groupBy, $this->pipeline);
+        $this->groupBy = null;
+
         return $this;
     }
 
@@ -159,11 +162,6 @@ final class ETL
             $this->limit = $limit;
         }
 
-        if ($this->groupBy !== null) {
-            $this->pipeline = new GroupByPipeline($this->groupBy, $this->pipeline);
-            $this->groupBy = null;
-        }
-
         return (new Rows())->merge(...\iterator_to_array($this->pipeline->process($this->limit)));
     }
 
@@ -198,6 +196,7 @@ final class ETL
     public function groupBy(string ...$entries) : self
     {
         $this->groupBy = new GroupBy(...$entries);
+        $this->pipeline = new GroupByPipeline($this->groupBy, $this->pipeline);
 
         return $this;
     }
@@ -274,11 +273,6 @@ final class ETL
      */
     public function run(callable $callback = null) : void
     {
-        if ($this->groupBy !== null) {
-            $this->pipeline = new GroupByPipeline($this->groupBy, $this->pipeline);
-            $this->groupBy = null;
-        }
-
         foreach ($this->pipeline->process($this->limit) as $rows) {
             if ($callback !== null) {
                 $callback($rows);

--- a/tests/Flow/ETL/Tests/Unit/ETLTest.php
+++ b/tests/Flow/ETL/Tests/Unit/ETLTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit;
 
 use Flow\ETL\DSL\Entry;
+use Flow\ETL\DSL\Transform;
 use Flow\ETL\ErrorHandler\IgnoreError;
 use Flow\ETL\ETL;
 use Flow\ETL\Exception\InvalidArgumentException;
@@ -789,8 +790,12 @@ ASCIITABLE,
             });
     }
 
-    public function test_group_by_multiple_columns() : void
+    public function test_group_by_multiple_columns_and_parallelize() : void
     {
+        $loader = $this->createMock(Loader::class);
+        $loader->expects($this->exactly(4))
+            ->method('load');
+
         $rows = ETL::process(
             new Rows(
                 Row::create(Entry::integer('id', 1), Entry::string('country', 'PL'), Entry::integer('age', 20), Entry::string('gender', 'male')),
@@ -804,6 +809,8 @@ ASCIITABLE,
             )
         )
             ->groupBy('country', 'gender')
+            ->parallelize(1)
+            ->write($loader)
             ->fetch();
 
         $this->assertEquals(
@@ -938,6 +945,33 @@ ASCIITABLE,
             ->limit(-1);
     }
 
+    public function test_overriding_group_by() : void
+    {
+        $rows = ETL::process(
+            new Rows(
+                Row::create(Entry::integer('id', 1), Entry::string('country', 'PL'), Entry::integer('age', 20)),
+                Row::create(Entry::integer('id', 2), Entry::string('country', 'PL'), Entry::integer('age', 20)),
+                Row::create(Entry::integer('id', 3), Entry::string('country', 'PL'), Entry::integer('age', 25)),
+                Row::create(Entry::integer('id', 4), Entry::string('country', 'PL'), Entry::integer('age', 30)),
+                Row::create(Entry::integer('id', 5), Entry::string('country', 'US'), Entry::integer('age', 40)),
+                Row::create(Entry::integer('id', 6), Entry::string('country', 'US'), Entry::integer('age', 40)),
+                Row::create(Entry::integer('id', 7), Entry::string('country', 'US'), Entry::integer('age', 45)),
+                Row::create(Entry::integer('id', 9), Entry::string('country', 'US'), Entry::integer('age', 50)),
+            )
+        )
+            ->groupBy('id')
+            ->groupBy('country')
+            ->fetch();
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(Entry::string('country', 'PL')),
+                Row::create(Entry::string('country', 'US')),
+            ),
+            $rows
+        );
+    }
+
     public function test_select() : void
     {
         $rows = ETL::process(
@@ -987,22 +1021,23 @@ ASCIITABLE,
     {
         $rows = ETL::process(
             new Rows(
-                Row::create(Entry::integer('id', 1), Entry::string('country', 'PL'), Entry::integer('age', 20)),
-                Row::create(Entry::integer('id', 2), Entry::string('country', 'PL'), Entry::integer('age', 20)),
-                Row::create(Entry::integer('id', 3), Entry::string('country', 'PL'), Entry::integer('age', 25)),
-                Row::create(Entry::integer('id', 4), Entry::string('country', 'PL'), Entry::integer('age', 30)),
-                Row::create(Entry::integer('id', 5), Entry::string('country', 'US'), Entry::integer('age', 40)),
-                Row::create(Entry::integer('id', 6), Entry::string('country', 'US'), Entry::integer('age', 40)),
-                Row::create(Entry::integer('id', 7), Entry::string('country', 'US'), Entry::integer('age', 45)),
-                Row::create(Entry::integer('id', 9), Entry::string('country', 'US'), Entry::integer('age', 50)),
-            )
+                    Row::create(Entry::integer('id', 1), Entry::string('country', 'PL'), Entry::integer('age', 20)),
+                    Row::create(Entry::integer('id', 2), Entry::string('country', 'PL'), Entry::integer('age', 20)),
+                    Row::create(Entry::integer('id', 3), Entry::string('country', 'PL'), Entry::integer('age', 25)),
+                    Row::create(Entry::integer('id', 4), Entry::string('country', 'PL'), Entry::integer('age', 30)),
+                    Row::create(Entry::integer('id', 5), Entry::string('country', 'US'), Entry::integer('age', 40)),
+                    Row::create(Entry::integer('id', 6), Entry::string('country', 'US'), Entry::integer('age', 40)),
+                    Row::create(Entry::integer('id', 7), Entry::string('country', 'US'), Entry::integer('age', 45)),
+                    Row::create(Entry::integer('id', 9), Entry::string('country', 'US'), Entry::integer('age', 50)),
+                )
         )
             ->aggregate(Aggregation::avg('age'))
+            ->rows(Transform::rename('age_avg', 'average_age'))
             ->fetch();
 
         $this->assertEquals(
             new Rows(
-                Row::create(Entry::float('age_avg', 33.75)),
+                Row::create(Entry::float('average_age', 33.75)),
             ),
             $rows
         );

--- a/tests/Flow/ETL/Tests/Unit/ETLTest.php
+++ b/tests/Flow/ETL/Tests/Unit/ETLTest.php
@@ -1021,15 +1021,15 @@ ASCIITABLE,
     {
         $rows = ETL::process(
             new Rows(
-                    Row::create(Entry::integer('id', 1), Entry::string('country', 'PL'), Entry::integer('age', 20)),
-                    Row::create(Entry::integer('id', 2), Entry::string('country', 'PL'), Entry::integer('age', 20)),
-                    Row::create(Entry::integer('id', 3), Entry::string('country', 'PL'), Entry::integer('age', 25)),
-                    Row::create(Entry::integer('id', 4), Entry::string('country', 'PL'), Entry::integer('age', 30)),
-                    Row::create(Entry::integer('id', 5), Entry::string('country', 'US'), Entry::integer('age', 40)),
-                    Row::create(Entry::integer('id', 6), Entry::string('country', 'US'), Entry::integer('age', 40)),
-                    Row::create(Entry::integer('id', 7), Entry::string('country', 'US'), Entry::integer('age', 45)),
-                    Row::create(Entry::integer('id', 9), Entry::string('country', 'US'), Entry::integer('age', 50)),
-                )
+                Row::create(Entry::integer('id', 1), Entry::string('country', 'PL'), Entry::integer('age', 20)),
+                Row::create(Entry::integer('id', 2), Entry::string('country', 'PL'), Entry::integer('age', 20)),
+                Row::create(Entry::integer('id', 3), Entry::string('country', 'PL'), Entry::integer('age', 25)),
+                Row::create(Entry::integer('id', 4), Entry::string('country', 'PL'), Entry::integer('age', 30)),
+                Row::create(Entry::integer('id', 5), Entry::string('country', 'US'), Entry::integer('age', 40)),
+                Row::create(Entry::integer('id', 6), Entry::string('country', 'US'), Entry::integer('age', 40)),
+                Row::create(Entry::integer('id', 7), Entry::string('country', 'US'), Entry::integer('age', 45)),
+                Row::create(Entry::integer('id', 9), Entry::string('country', 'US'), Entry::integer('age', 50)),
+            )
         )
             ->aggregate(Aggregation::avg('age'))
             ->rows(Transform::rename('age_avg', 'average_age'))


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>GroupByPipeline execution</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Previous version of GroupByPipeline wasn't allowing any future transformations after grouping which was incorrect. For example, renaming is a very common next step.