### PR TITLE
Get schema from existing rows

### DIFF
--- a/src/Flow/ETL/Row.php
+++ b/src/Flow/ETL/Row.php
@@ -7,6 +7,7 @@ namespace Flow\ETL;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema;
 use Flow\Serializer\Serializable;
 
 /**
@@ -125,6 +126,17 @@ final class Row implements Serializable
     public function rename(string $currentName, string $newName) : self
     {
         return new self($this->entries->rename($currentName, $newName));
+    }
+
+    public function schema() : Schema
+    {
+        $definitions = [];
+
+        foreach ($this->entries->all() as $entry) {
+            $definitions[] = $entry->definition();
+        }
+
+        return new Schema(...$definitions);
     }
 
     /**

--- a/src/Flow/ETL/Row/Entry.php
+++ b/src/Flow/ETL/Row/Entry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row;
 
+use Flow\ETL\Row\Schema\Definition;
 use Flow\Serializer\Serializable;
 
 /**
@@ -15,6 +16,8 @@ use Flow\Serializer\Serializable;
 interface Entry extends Serializable
 {
     public function __toString() : string;
+
+    public function definition() : Definition;
 
     public function is(string $name) : bool;
 

--- a/src/Flow/ETL/Row/Entry/ArrayEntry.php
+++ b/src/Flow/ETL/Row/Entry/ArrayEntry.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Row\Entry;
 use Flow\ArrayComparison\ArrayComparison;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<array<mixed>, array{name: string, value: array<mixed>}>
@@ -51,6 +52,11 @@ final class ArrayEntry implements Entry
     {
         $this->name = $data['name'];
         $this->value = $data['value'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::array($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/BooleanEntry.php
+++ b/src/Flow/ETL/Row/Entry/BooleanEntry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<bool, array{name: string, value: bool}>
@@ -70,6 +71,11 @@ final class BooleanEntry implements Entry
     {
         $this->name = $data['name'];
         $this->value = $data['value'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::boolean($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/CollectionEntry.php
+++ b/src/Flow/ETL/Row/Entry/CollectionEntry.php
@@ -8,6 +8,7 @@ use Flow\ArrayComparison\ArrayComparison;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<array<Entries>, array{name: string, entries: array<Entries>}>
@@ -52,6 +53,11 @@ final class CollectionEntry implements Entry
     {
         $this->name = $data['name'];
         $this->entries = $data['entries'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::collection($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/DateTimeEntry.php
+++ b/src/Flow/ETL/Row/Entry/DateTimeEntry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<\DateTimeInterface, array{name: string, value: \DateTimeInterface}>
@@ -44,6 +45,11 @@ final class DateTimeEntry implements Entry
     {
         $this->name = $data['name'];
         $this->value = $data['value'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::dateTime($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/FloatEntry.php
+++ b/src/Flow/ETL/Row/Entry/FloatEntry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<float, array{name: string, value: float, precision: int}>
@@ -60,6 +61,11 @@ final class FloatEntry implements Entry
         $this->name = $data['name'];
         $this->value = $data['value'];
         $this->precision = $data['precision'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::float($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/IntegerEntry.php
+++ b/src/Flow/ETL/Row/Entry/IntegerEntry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<int, array{name: string, value: integer}>
@@ -56,6 +57,11 @@ final class IntegerEntry implements Entry
     {
         $this->name = $data['name'];
         $this->value = $data['value'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::integer($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/JsonEntry.php
+++ b/src/Flow/ETL/Row/Entry/JsonEntry.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Row\Entry;
 use Flow\ArrayComparison\ArrayComparison;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<string, array{name: string, value: array<mixed>, object: boolean}>
@@ -121,6 +122,11 @@ final class JsonEntry implements Entry
         $this->name = $data['name'];
         $this->value = $data['value'];
         $this->object = $data['object'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::json($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/NullEntry.php
+++ b/src/Flow/ETL/Row/Entry/NullEntry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<null, array{name: string}>
@@ -40,6 +41,11 @@ final class NullEntry implements Entry
     public function __unserialize(array $data) : void
     {
         $this->name = $data['name'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::null($this->name);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/ObjectEntry.php
+++ b/src/Flow/ETL/Row/Entry/ObjectEntry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<object, array{name: string, value: object}>
@@ -44,6 +45,11 @@ final class ObjectEntry implements Entry
     {
         $this->name = $data['name'];
         $this->value = $data['value'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::object($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/StringEntry.php
+++ b/src/Flow/ETL/Row/Entry/StringEntry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<string, array{name: string, value: string}>
@@ -68,6 +69,11 @@ final class StringEntry implements Entry
     {
         $this->name = $data['name'];
         $this->value = $data['value'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::string($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/StructureEntry.php
+++ b/src/Flow/ETL/Row/Entry/StructureEntry.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Row\Entry;
 use Flow\ArrayComparison\ArrayComparison;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Definition;
 
 /**
  * @implements Entry<array<Entry>, array{name: string, entries: array<Entry>}>
@@ -54,6 +55,11 @@ final class StructureEntry implements Entry
     {
         $this->name = $data['name'];
         $this->entries = $data['entries'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::structure($this->name, false);
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Schema.php
+++ b/src/Flow/ETL/Row/Schema.php
@@ -9,6 +9,7 @@ use Flow\ETL\Row\Schema\Definition;
 use Flow\Serializer\Serializable;
 
 /**
+ * @psalm-immutable
  * @implements Serializable<array{definitions: array<string, Definition>}>
  */
 final class Schema implements \Countable, Serializable
@@ -74,5 +75,22 @@ final class Schema implements \Countable, Serializable
         }
 
         return $this->definitions[$entry];
+    }
+
+    public function merge(self $schema) : self
+    {
+        $newDefinitions = $this->definitions;
+
+        foreach ($schema->definitions as $entry => $definition) {
+            if (!\array_key_exists($definition->entry(), $newDefinitions)) {
+                $newDefinitions[$entry] = $definition->nullable();
+            }
+
+            if ($definition->isNullable() && !$newDefinitions[$entry]->isNullable()) {
+                $newDefinitions[$entry] = $newDefinitions[$entry]->nullable();
+            }
+        }
+
+        return new self(...\array_values($newDefinitions));
     }
 }

--- a/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/Flow/ETL/Row/Schema/Definition.php
@@ -9,14 +9,17 @@ use Flow\ETL\Row\Entry\ArrayEntry;
 use Flow\ETL\Row\Entry\BooleanEntry;
 use Flow\ETL\Row\Entry\CollectionEntry;
 use Flow\ETL\Row\Entry\DateTimeEntry;
+use Flow\ETL\Row\Entry\FloatEntry;
 use Flow\ETL\Row\Entry\IntegerEntry;
 use Flow\ETL\Row\Entry\JsonEntry;
+use Flow\ETL\Row\Entry\NullEntry;
 use Flow\ETL\Row\Entry\ObjectEntry;
 use Flow\ETL\Row\Entry\StringEntry;
 use Flow\ETL\Row\Entry\StructureEntry;
 use Flow\Serializer\Serializable;
 
 /**
+ * @psalm-immutable
  * @implements Serializable<array{entry: string, class:class-string, nullable: boolean, constraint: null|Constraint}>
  */
 final class Definition implements Serializable
@@ -46,52 +49,159 @@ final class Definition implements Serializable
         $this->entry = $entry;
     }
 
-    // @codeCoverageIgnoreStart
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function array(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, ArrayEntry::class, $nullable, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function boolean(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, BooleanEntry::class, $nullable, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function collection(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, CollectionEntry::class, $nullable, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function dateTime(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, DateTimeEntry::class, $nullable, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
+    public static function float(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
+    {
+        return new self($entry, FloatEntry::class, $nullable, $constraint);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function integer(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, IntegerEntry::class, $nullable, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function json(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, JsonEntry::class, $nullable, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     *
+     * @return static
+     */
+    public static function null(string $entry) : self
+    {
+        return new self($entry, NullEntry::class, true);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function object(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, ObjectEntry::class, $nullable, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function string(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, StringEntry::class, $nullable, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     *
+     * @param string $entry
+     * @param bool $nullable
+     * @param null|Constraint $constraint
+     *
+     * @return static
+     */
     public static function structure(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, StructureEntry::class, $nullable, $constraint);
     }
 
+    // @codeCoverageIgnoreStart
     public function __serialize() : array
     {
         return [
@@ -116,6 +226,11 @@ final class Definition implements Serializable
     }
     // @codeCoverageIgnoreEnd
 
+    public function isNullable() : bool
+    {
+        return $this->nullable;
+    }
+
     /**
      * @param Entry $entry
      *
@@ -132,9 +247,15 @@ final class Definition implements Serializable
         }
 
         if ($this->constraint !== null) {
+            /** @psalm-suppress ImpureMethodCall */
             return $this->constraint->isSatisfiedBy($entry);
         }
 
         return true;
+    }
+
+    public function nullable() : self
+    {
+        return new self($this->entry, $this->class, true, $this->constraint);
     }
 }

--- a/src/Flow/ETL/Rows.php
+++ b/src/Flow/ETL/Rows.php
@@ -9,6 +9,7 @@ use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row\Comparator;
 use Flow\ETL\Row\Comparator\NativeComparator;
 use Flow\ETL\Row\Entries;
+use Flow\ETL\Row\Schema;
 use Flow\ETL\Row\Sort;
 use Flow\Serializer\Serializable;
 
@@ -404,6 +405,25 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate, Serial
     public function reverse() : self
     {
         return new self(...\array_reverse($this->rows));
+    }
+
+    public function schema() : Schema
+    {
+        if (!$this->count()) {
+            return new Schema();
+        }
+
+        /** @var ?Schema $schema */
+        $schema = null;
+
+        foreach ($this->rows as $row) {
+            $schema = $schema === null
+                ? $row->schema()
+                : $schema->merge($row->schema());
+        }
+
+        /** @var Schema $schema */
+        return $schema;
     }
 
     /**

--- a/tests/Flow/ETL/Tests/Unit/RowTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit;
 
+use Flow\ETL\DSL\Entry;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Entry\ArrayEntry;
@@ -49,6 +50,51 @@ final class RowTest extends TestCase
             new Row(new Entries(new StructureEntry('json', new IntegerEntry('5', 5), new IntegerEntry('2', 2), new IntegerEntry('3', 3)))),
             new Row(new Entries(new StructureEntry('json', new IntegerEntry('1', 1), new IntegerEntry('2', 2), new IntegerEntry('3', 3)))),
         ];
+    }
+
+    public function test_getting_schema_from_row() : void
+    {
+        $row = Row::create(
+            Entry::integer('id', \random_int(100, 100000)),
+            Entry::float('price', \random_int(100, 100000) / 100),
+            Entry::boolean('deleted', false),
+            Entry::datetime('created-at', new \DateTimeImmutable('now')),
+            Entry::null('phase'),
+            Entry::array(
+                'array',
+                [
+                    ['id' => 1, 'status' => 'NEW'],
+                    ['id' => 2, 'status' => 'PENDING'],
+                ]
+            ),
+            Entry::structure(
+                'items',
+                Entry::integer('item-id', 1),
+                Entry::string('name', 'one'),
+            ),
+            Entry::collection(
+                'tags',
+                new Row\Entries(Entry::integer('item-id', 1), Entry::string('name', 'one')),
+                new Row\Entries(Entry::integer('item-id', 2), Entry::string('name', 'two')),
+                new Row\Entries(Entry::integer('item-id', 3), Entry::string('name', 'three'))
+            ),
+            Entry::object('object', new \ArrayIterator([1, 2, 3]))
+        );
+
+        $this->assertEquals(
+            new Row\Schema(
+                Row\Schema\Definition::integer('id'),
+                Row\Schema\Definition::float('price'),
+                Row\Schema\Definition::boolean('deleted'),
+                Row\Schema\Definition::dateTime('created-at'),
+                Row\Schema\Definition::null('phase'),
+                Row\Schema\Definition::array('array'),
+                Row\Schema\Definition::structure('items'),
+                Row\Schema\Definition::collection('tags'),
+                Row\Schema\Definition::object('object'),
+            ),
+            $row->schema()
+        );
     }
 
     /**

--- a/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -14,6 +14,8 @@ use Flow\ETL\Row\Entry\IntegerEntry;
 use Flow\ETL\Row\Entry\NullEntry;
 use Flow\ETL\Row\Entry\ObjectEntry;
 use Flow\ETL\Row\Entry\StringEntry;
+use Flow\ETL\Row\Schema;
+use Flow\ETL\Row\Schema\Definition;
 use Flow\ETL\Rows;
 use PHPUnit\Framework\TestCase;
 
@@ -507,6 +509,24 @@ final class RowsTest extends TestCase
     public function test_rows_diff_right(Rows $expected, Rows $left, Rows $right) : void
     {
         $this->assertEquals($expected, $left->diffRight($right));
+    }
+
+    public function test_rows_schema() : void
+    {
+        $rows = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('name', 'foo')),
+            Row::create(Entry::integer('id', 1), Entry::null('name')),
+            Row::create(Entry::integer('id', 1), Entry::string('name', 'bar'), Entry::array('tags', ['a', 'b'])),
+        );
+
+        $this->assertEquals(
+            new Schema(
+                Definition::integer('id'),
+                Definition::string('name', $nullable = true),
+                Definition::array('tags', $nullable = true)
+            ),
+            $rows->schema()
+        );
     }
 
     public function test_rows_serialization() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Getting schema from existing Rows</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Obviously getting schema from existing Rows will not be able to return any type of custom Constraints but it's good enough if you only want to check types/nullability