### PR TITLE
Added Rows::join methods

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/flow-php/array-dot.git",
-                "reference": "d5adfe8e6c4304d8cc6b95f7e9c9db4447c2a06e"
+                "reference": "ac70f3beb693241c89455712f07b98b957f6766b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flow-php/array-dot/zipball/d5adfe8e6c4304d8cc6b95f7e9c9db4447c2a06e",
-                "reference": "d5adfe8e6c4304d8cc6b95f7e9c9db4447c2a06e",
+                "url": "https://api.github.com/repos/flow-php/array-dot/zipball/ac70f3beb693241c89455712f07b98b957f6766b",
+                "reference": "ac70f3beb693241c89455712f07b98b957f6766b",
                 "shasum": ""
             },
             "require": {
@@ -53,7 +53,7 @@
                 "issues": "https://github.com/flow-php/array-dot/issues",
                 "source": "https://github.com/flow-php/array-dot/tree/1.x"
             },
-            "time": "2022-03-04T21:12:40+00:00"
+            "time": "2022-03-24T21:19:03+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Flow/ETL/DSL/Entry.php
+++ b/src/Flow/ETL/DSL/Entry.php
@@ -10,6 +10,8 @@ use Flow\ETL\Row\Entry as RowEntry;
 class Entry
 {
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param array<mixed> $data
      *
@@ -21,6 +23,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param bool $value
      *
@@ -34,6 +38,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param Entries ...$entries
      *
@@ -47,6 +53,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param \DateTimeInterface $value
      *
@@ -60,6 +68,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param RowEntry ...$entries
      *
      * @throws \Flow\ETL\Exception\InvalidArgumentException
@@ -72,6 +82,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param float $value
      *
@@ -85,6 +97,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param int $value
      *
@@ -98,6 +112,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param array<mixed> $data
      *
@@ -109,6 +125,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param array<mixed> $data
      *
@@ -120,6 +138,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      *
      * @throws \Flow\ETL\Exception\InvalidArgumentException
@@ -132,6 +152,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param object $object
      *
@@ -145,6 +167,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param string $value
      *
@@ -158,6 +182,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param string $value
      *
@@ -171,6 +197,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param string $value
      *
@@ -184,6 +212,8 @@ class Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $name
      * @param RowEntry ...$entries
      *

--- a/src/Flow/ETL/Join/Condition.php
+++ b/src/Flow/ETL/Join/Condition.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Join;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Row;
+
+/**
+ * @psalm-immutable
+ */
+final class Condition
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $entries;
+
+    private string $joinPrefix;
+
+    /**
+     * @param array<string, string> $entries
+     * @param string $joinPrefix
+     */
+    private function __construct(array $entries, string $joinPrefix = '')
+    {
+        $this->entries = $entries;
+        $this->joinPrefix = $joinPrefix;
+    }
+
+    /**
+     * @param array<string, string> $entries
+     * @param string $joinPrefix
+     *
+     * @return self
+     */
+    public static function on(array $entries, string $joinPrefix = '') : self
+    {
+        return new self($entries, $joinPrefix);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function left() : array
+    {
+        return \array_keys($this->entries);
+    }
+
+    public function meet(Row $left, Row $right) : bool
+    {
+        foreach ($this->entries as $leftEntry => $rightEntry) {
+            try {
+                if ($left->valueOf($leftEntry) !== $right->valueOf($rightEntry)) {
+                    return false;
+                }
+            } catch (InvalidArgumentException $e) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function prefix() : string
+    {
+        return $this->joinPrefix;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function right() : array
+    {
+        return \array_values($this->entries);
+    }
+}

--- a/src/Flow/ETL/Row.php
+++ b/src/Flow/ETL/Row.php
@@ -101,6 +101,14 @@ final class Row implements Serializable
         return new self(new Entries(...$this->entries->map($mapper)));
     }
 
+    /**
+     * @param Row $row
+     * @param string $prefix
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return self
+     */
     public function merge(self $row, string $prefix = '_') : self
     {
         return new self(

--- a/src/Flow/ETL/Row/Entry/StringEntry.php
+++ b/src/Flow/ETL/Row/Entry/StringEntry.php
@@ -40,6 +40,8 @@ final class StringEntry implements Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @throws InvalidArgumentException
      */
     public static function lowercase(string $name, string $value) : self
@@ -48,6 +50,8 @@ final class StringEntry implements Entry
     }
 
     /**
+     * @psalm-pure
+     *
      * @throws InvalidArgumentException
      */
     public static function uppercase(string $name, string $value) : self

--- a/src/Flow/ETL/Row/Schema.php
+++ b/src/Flow/ETL/Row/Schema.php
@@ -95,4 +95,32 @@ final class Schema implements \Countable, Serializable
 
         return new self(...\array_values($newDefinitions));
     }
+
+    public function nullable() : self
+    {
+        $definitions = [];
+
+        foreach ($this->definitions as $definition) {
+            if (!$definition->isNullable()) {
+                $definitions[] = $definition->nullable();
+            } else {
+                $definitions[] = $definition;
+            }
+        }
+
+        return new self(...$definitions);
+    }
+
+    public function without(string ...$entries) : self
+    {
+        $definitions = [];
+
+        foreach ($this->definitions as $definition) {
+            if (!\in_array($definition->entry(), $entries, true)) {
+                $definitions[] = $definition;
+            }
+        }
+
+        return new self(...$definitions);
+    }
 }

--- a/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
@@ -29,4 +29,35 @@ final class SchemaTest extends TestCase
 
         $this->assertSame(['id', 'Id'], $schema->entries());
     }
+
+    public function test_making_whole_schema_nullable() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id', $nullable = false),
+            Schema\Definition::string('name', $nullable = true)
+        );
+
+        $this->assertEquals(
+            new Schema(
+                Schema\Definition::integer('id', $nullable = true),
+                Schema\Definition::string('name', $nullable = true)
+            ),
+            $schema->nullable()
+        );
+    }
+
+    public function test_removing_elements_from_schema() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name'),
+        );
+
+        $this->assertEquals(
+            new Schema(
+                Schema\Definition::integer('id'),
+            ),
+            $schema->without('name', 'tags')
+        );
+    }
 }

--- a/tests/Flow/ETL/Tests/Unit/RowsJoinTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowsJoinTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Join\Condition;
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use PHPUnit\Framework\TestCase;
+
+final class RowsJoinTest extends TestCase
+{
+    public function test_inner_empty() : void
+    {
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 4), Entry::string('country', 'FR')),
+        );
+
+        $joined = $left->joinInner(
+            new Rows(),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(),
+            $joined
+        );
+    }
+
+    public function test_inner_join() : void
+    {
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 4), Entry::string('country', 'FR')),
+        );
+
+        $joined = $left->joinInner(
+            new Rows(
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(Entry::integer('id', 1), Entry::string('country', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::integer('id', 2), Entry::string('country', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::integer('id', 3), Entry::string('country', 'US'), Entry::string('name', 'United States')),
+            ),
+            $joined
+        );
+    }
+
+    public function test_inner_join_into_empty() : void
+    {
+        $left = new Rows();
+
+        $joined = $left->joinInner(
+            new Rows(
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(),
+            $joined
+        );
+    }
+
+    public function test_inner_join_with_duplicated_entries() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Merged entries names must be unique, given: [id, country] + [id, code, name]. Please consider using Condition, join prefix option');
+
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 4), Entry::string('country', 'FR')),
+        );
+
+        $left->joinInner(
+            new Rows(
+                Row::create(Entry::integer('id', 101), Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::integer('id', 102), Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::integer('id', 103), Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+    }
+
+    public function test_left_join() : void
+    {
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'FR')),
+        );
+
+        $joined = $left->joinLeft(
+            new Rows(
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(Entry::integer('id', 1), Entry::string('country', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::integer('id', 2), Entry::string('country', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::integer('id', 3), Entry::string('country', 'FR'), Entry::null('name')),
+            ),
+            $joined
+        );
+    }
+
+    public function test_left_join_empty() : void
+    {
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'FR')),
+        );
+
+        $joined = $left->joinLeft(
+            new Rows(),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+                Row::create(Entry::integer('id', 2), Entry::string('country', 'US')),
+                Row::create(Entry::integer('id', 3), Entry::string('country', 'FR')),
+            ),
+            $joined
+        );
+    }
+
+    public function test_left_join_to_empty() : void
+    {
+        $left = new Rows();
+
+        $joined = $left->joinLeft(
+            new Rows(
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(),
+            $joined
+        );
+    }
+
+    public function test_left_join_with_the_duplicated_columns() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Merged entries names must be unique, given: [id, country] + [id, code, name]. Please consider using Condition, join prefix option');
+
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'FR')),
+        );
+
+        $left->joinLeft(
+            new Rows(
+                Row::create(Entry::integer('id', 100), Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::integer('id', 101), Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::integer('id', 102), Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+    }
+
+    public function test_right_join() : void
+    {
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 4), Entry::string('country', 'FR')),
+        );
+
+        $joined = $left->joinRight(
+            new Rows(
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland'), Entry::integer('id', 1)),
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland'), Entry::integer('id', 2)),
+                Row::create(Entry::string('code', 'US'), Entry::string('name', 'United States'), Entry::integer('id', 3)),
+                Row::create(Entry::string('code', 'GB'), Entry::string('name', 'Great Britain'), Entry::null('id')),
+            ),
+            $joined
+        );
+    }
+
+    public function test_right_join_empty() : void
+    {
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 4), Entry::string('country', 'FR')),
+        );
+
+        $joined = $left->joinRight(
+            new Rows(),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(),
+            $joined
+        );
+    }
+
+    public function test_right_join_to_empty() : void
+    {
+        $left = new Rows();
+
+        $joined = $left->joinRight(
+            new Rows(
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            $joined
+        );
+    }
+
+    public function test_right_join_with_duplicated_entry_names() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Merged entries names must be unique, given: [id, code, name] + [id, country]. Please consider using Condition, join prefix option');
+
+        $left = new Rows(
+            Row::create(Entry::integer('id', 1), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 2), Entry::string('country', 'PL')),
+            Row::create(Entry::integer('id', 3), Entry::string('country', 'US')),
+            Row::create(Entry::integer('id', 4), Entry::string('country', 'FR')),
+        );
+
+        $left->joinRight(
+            new Rows(
+                Row::create(Entry::integer('id', 101), Entry::string('code', 'PL'), Entry::string('name', 'Poland')),
+                Row::create(Entry::integer('id', 102), Entry::string('code', 'US'), Entry::string('name', 'United States')),
+                Row::create(Entry::integer('id', 103), Entry::string('code', 'GB'), Entry::string('name', 'Great Britain')),
+            ),
+            Condition::on(['country' => 'code'])
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Rows::joinLeft</li>
    <li>Rows::joinRight</li>
    <li>Rows::joinInner</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Those methods are going to be used by DataFrame::join implementation later, they might still change and should not be used directly anywhere. 