### PR TITLE
Changed default transformers behavior from Entries::add to Entries::set

### DIFF
--- a/src/Flow/ETL/Transformer/ArrayCollectionGetTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayCollectionGetTransformer.php
@@ -90,7 +90,7 @@ final class ArrayCollectionGetTransformer implements Transformer
                 throw new RuntimeException("Extracted value from path \"{$path}\" is not array but {$type}");
             }
 
-            return $row->add(
+            return $row->set(
                 new Row\Entry\ArrayEntry(
                     $this->newEntryName,
                     $extractedValues

--- a/src/Flow/ETL/Transformer/ArrayCollectionMergeTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayCollectionMergeTransformer.php
@@ -60,7 +60,7 @@ final class ArrayCollectionMergeTransformer implements Transformer
             }
 
             /** @psalm-suppress MixedArgument */
-            return $row->add(
+            return $row->set(
                 new Row\Entry\ArrayEntry(
                     $this->newEntryName,
                     /** @phpstan-ignore-next-line  */

--- a/src/Flow/ETL/Transformer/ArrayDotGetTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayDotGetTransformer.php
@@ -58,7 +58,7 @@ final class ArrayDotGetTransformer implements Transformer
                 throw new RuntimeException("{$this->arrayEntryName} is not ArrayEntry but {$entryClass}");
             }
 
-            return $row->add(
+            return $row->set(
                 $this->entryFactory->create(
                     $this->newEntryName,
                     array_dot_get($arrayEntry->value(), $this->path)

--- a/src/Flow/ETL/Transformer/ArrayMergeTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayMergeTransformer.php
@@ -56,7 +56,7 @@ final class ArrayMergeTransformer implements Transformer
                 $entryValues[] = $arrayEntry->value();
             }
 
-            return $row->add(new Row\Entry\ArrayEntry(
+            return $row->set(new Row\Entry\ArrayEntry(
                 $this->newEntryName,
                 \array_merge(...$entryValues)
             ));

--- a/src/Flow/ETL/Transformer/HashTransformer.php
+++ b/src/Flow/ETL/Transformer/HashTransformer.php
@@ -65,7 +65,7 @@ final class HashTransformer implements Transformer
                 }
             }
 
-            return $row->add(Entry::string($this->newEntryName, \hash($this->algorithm, \implode('', $values), false)));
+            return $row->set(Entry::string($this->newEntryName, \hash($this->algorithm, \implode('', $values), false)));
         };
 
         return $rows->map($transformer);

--- a/src/Flow/ETL/Transformer/MathOperationTransformer.php
+++ b/src/Flow/ETL/Transformer/MathOperationTransformer.php
@@ -112,10 +112,10 @@ final class MathOperationTransformer implements Transformer
             };
 
             if (\is_float($value)) {
-                return $row->add(new Row\Entry\FloatEntry($this->newEntryName, $value));
+                return $row->set(new Row\Entry\FloatEntry($this->newEntryName, $value));
             }
 
-            return $row->add(new Row\Entry\IntegerEntry($this->newEntryName, $value));
+            return $row->set(new Row\Entry\IntegerEntry($this->newEntryName, $value));
         };
 
         return $rows->map($transformer);

--- a/src/Flow/ETL/Transformer/MathValueOperationTransformer.php
+++ b/src/Flow/ETL/Transformer/MathValueOperationTransformer.php
@@ -103,10 +103,10 @@ final class MathValueOperationTransformer implements Transformer
             };
 
             if (\is_float($value)) {
-                return $row->add(new Row\Entry\FloatEntry($this->newEntryName, $value));
+                return $row->set(new Row\Entry\FloatEntry($this->newEntryName, $value));
             }
 
-            return $row->add(new Row\Entry\IntegerEntry($this->newEntryName, $value));
+            return $row->set(new Row\Entry\IntegerEntry($this->newEntryName, $value));
         };
 
         return $rows->map($transformer);

--- a/src/Flow/ETL/Transformer/ObjectMethodTransformer.php
+++ b/src/Flow/ETL/Transformer/ObjectMethodTransformer.php
@@ -76,7 +76,7 @@ final class ObjectMethodTransformer implements Transformer
                 throw new RuntimeException("\"{$this->objectEntryName}\" is object does not have \"{$this->method}\" method.");
             }
 
-            return $row->add($this->entryFactory->create(
+            return $row->set($this->entryFactory->create(
                 $this->newEntryName,
                 /** @phpstan-ignore-next-line */
                 \call_user_func([$object, $this->method], ...$this->parameters)

--- a/src/Flow/ETL/Transformer/ObjectToArrayTransformer.php
+++ b/src/Flow/ETL/Transformer/ObjectToArrayTransformer.php
@@ -47,8 +47,7 @@ final class ObjectToArrayTransformer implements Transformer
             }
 
             $entries = $row->entries()
-                ->remove($this->objectEntryName)
-                ->add(
+                ->set(
                     new Row\Entry\ArrayEntry(
                         $this->objectEntryName,
                         $this->hydrator->extract(

--- a/src/Flow/ETL/Transformer/StaticEntryTransformer.php
+++ b/src/Flow/ETL/Transformer/StaticEntryTransformer.php
@@ -36,7 +36,7 @@ final class StaticEntryTransformer implements Transformer
         /**
          * @psalm-var pure-callable(Row $row) : Row $transformer
          */
-        $transformer = fn (Row $row) : Row => $row->add($this->entry);
+        $transformer = fn (Row $row) : Row => $row->set($this->entry);
 
         return $rows->map($transformer);
     }

--- a/src/Flow/ETL/Transformer/StringConcatTransformer.php
+++ b/src/Flow/ETL/Transformer/StringConcatTransformer.php
@@ -56,7 +56,7 @@ final class StringConcatTransformer implements Transformer
                 $values[] = $entry->toString();
             }
 
-            return $row->add(
+            return $row->set(
                 new Row\Entry\StringEntry(
                     $this->newEntryName,
                     \implode($this->glue, $values)


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>default transformers behavior from Entries::add to Entries::set</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This should simplify pipelines by reduce number of operations in case entry needs to be updated 