### PR TITLE
List Entry

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -140,6 +140,7 @@ return (new PhpCsFixer\Config())
                 'constant_public',
                 'constant_protected',
                 'constant_private',
+                'case',
                 'property_public_static',
                 'property_protected_static',
                 'property_private_static',

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ All entries are available through [DSL\Entry](src/Flow/ETL/DSL/Entry.php)
 * [float](src/Flow/ETL/Row/Entry/FloatEntry.php)
 * [integer](src/Flow/ETL/Row/Entry/IntegerEntry.php)
 * [json](src/Flow/ETL/Row/Entry/JsonEntry.php)  
+* [list](src/Flow/ETL/Row/Entry/ListEntry.php) - strongly typed array
 * [null](src/Flow/ETL/Row/Entry/NullEntry.php)
 * [object](src/Flow/ETL/Row/Entry/ObjectEntry.php)
 * [string](src/Flow/ETL/Row/Entry/StringEntry.php)
@@ -210,41 +211,6 @@ Adapters might also define some custom transformers.
     * [callback row](src/Flow/ETL/Transformer/CallbackRowTransformer.php) - [tests](tests/Flow/ETL/Tests/Unit/Transformer/CallbackRowTransformerTest.php)
 
 Some transformers come with complex configuration, please find more details [here](/docs/complex_transformers.md).
-
-### Asynchronous Processing 
-
-Currently Flow is supporting only local multiprocess asynchronous processing.
-
-In order to process data asynchronously one of the following adapters must be first installed:
-
-* [etl-adapter-amphp](https://github.com/flow-php/etl-adapter-amphp)
-* [etl-adapter-reactphp](https://github.com/flow-php/etl-adapter-reactphp)
-
-Code example: 
-
-```php
-<?php
-(Flow::setUp(Config::builder()))
-    ->read(new CSVExtractor($path = __DIR__ . '/data/dataset.csv', 10_000, 0))
-    ->pipeline(
-        new LocalSocketPipeline(
-            SocketServer::unixDomain(__DIR__ . "/var/run/", $logger),
-            new ChildProcessLauncher(__DIR__ . "/vendor/bin/worker-amp", $logger),
-            $workers = 8
-        )
-    )
-    ->rows(Transform::array_unpack('row'))
-    ->drop('row')
-    ->rows(Transform::to_integer("id"))
-    ->rows(Transform::string_concat(['name', 'last_name'], ' ', 'name'))
-    ->drop('last_name')
-    ->load(new DbalLoader($tableName, $chunkSize = 1000, $dbConnectionParams))
-    ->run();
-```
-
-Following ilustration presents current state and future plans of the asynchronouse processing in flow 
-
-![async](docs/img/processing_modes.png)
 
 ### Serialization
 
@@ -368,6 +334,41 @@ data entries.
 
 **❗ If adapter that you are looking for is not available yet, and you are willing to work on one, feel free to create one as a standalone repository.**
 **Well designed and documented adapters can be pulled into `flow-php` organization that will give them maintenance and security support from the organization.** 
+
+### Asynchronous Processing
+
+Currently Flow is supporting only local multiprocess asynchronous processing.
+
+In order to process data asynchronously one of the following adapters must be first installed:
+
+* [etl-adapter-amphp](https://github.com/flow-php/etl-adapter-amphp)
+* [etl-adapter-reactphp](https://github.com/flow-php/etl-adapter-reactphp)
+
+Code example:
+
+```php
+<?php
+(Flow::setUp(Config::builder()))
+    ->read(new CSVExtractor($path = __DIR__ . '/data/dataset.csv', 10_000, 0))
+    ->pipeline(
+        new LocalSocketPipeline(
+            SocketServer::unixDomain(__DIR__ . "/var/run/", $logger),
+            new ChildProcessLauncher(__DIR__ . "/vendor/bin/worker-amp", $logger),
+            $workers = 8
+        )
+    )
+    ->rows(Transform::array_unpack('row'))
+    ->drop('row')
+    ->rows(Transform::to_integer("id"))
+    ->rows(Transform::string_concat(['name', 'last_name'], ' ', 'name'))
+    ->drop('last_name')
+    ->load(new DbalLoader($tableName, $chunkSize = 1000, $dbConnectionParams))
+    ->run();
+```
+
+Following ilustration presents current state and future plans of the asynchronouse processing in flow
+
+![async](docs/img/processing_modes.png)
 
 ## Process
 
@@ -730,6 +731,7 @@ $flow->read($from)
 
 - [all](src/Flow/ETL/Row/Schema/Constraint/All.php)
 - [any](src/Flow/ETL/Row/Schema/Constraint/Any.php)
+- [collection type](src/Flow/ETL/Row/Schema/Constraint/CollectionType.php)
 - [same as](src/Flow/ETL/Row/Schema/Constraint/SameAs.php)
 - [is instance of](src/Flow/ETL/Row/Schema/Constraint/IsInstanceOf.php)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Except typical ETL use cases (Extract, Transform, Load), Flow can be also used f
 composer require flow-php/etl:1.x@dev
 ```
 
+Until project get first stable release it's recommended to lock it to specific
+commit version in your composer.lock file. 
+
 ## Typical Use Cases
 
 * Sync data from external systems (API)
@@ -140,6 +143,8 @@ All entries are available through [DSL\Entry](src/Flow/ETL/DSL/Entry.php)
 * [object](src/Flow/ETL/Row/Entry/ObjectEntry.php)
 * [string](src/Flow/ETL/Row/Entry/StringEntry.php)
 * [structure](src/Flow/ETL/Row/Entry/StructureEntry.php)
+
+While adding new entry type, please follow the [checklist](docs/new_type.md). 
 
 > Entry names are case-sensitive, `entry` is not the same as `Entry`.
 

--- a/docs/new_type.md
+++ b/docs/new_type.md
@@ -1,0 +1,10 @@
+# New Types
+
+Introducing new data types/structures is not only about implementing `Entry`
+interface, below you can find list of things that must be checked.
+
+* Schema 
+  * [Definition](/src/Flow/ETL/Row/Schema/Definition.php)
+  * [Constraint](/src/Flow/ETL/Row/Schema/Constraint.php)
+* [EntryFactory](/src/Flow/ETL/Row/EntryFactory.php)
+* [EntryConverter](/src/Flow/ETL/Row/EntryConverter.php)

--- a/src/Flow/ETL/DSL/Entry.php
+++ b/src/Flow/ETL/DSL/Entry.php
@@ -148,6 +148,20 @@ class Entry
     /**
      * @psalm-pure
      *
+     * @param array<\DateTimeInterface> $value
+     *
+     * @throws \Flow\ETL\Exception\InvalidArgumentException
+     *
+     * @return RowEntry\ListEntry
+     */
+    final public static function list_of_datetime(string $name, array $value) : RowEntry
+    {
+        return new RowEntry\ListEntry($name, Type::dateTime, $value);
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param array<float> $value
      *
      * @throws \Flow\ETL\Exception\InvalidArgumentException

--- a/src/Flow/ETL/DSL/Entry.php
+++ b/src/Flow/ETL/DSL/Entry.php
@@ -156,7 +156,7 @@ class Entry
      */
     final public static function list_of_datetime(string $name, array $value) : RowEntry
     {
-        return new RowEntry\ListEntry($name, Type::dateTime, $value);
+        return new RowEntry\ListEntry($name, Type::datetime, $value);
     }
 
     /**

--- a/src/Flow/ETL/DSL/Entry.php
+++ b/src/Flow/ETL/DSL/Entry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\DSL;
 
 use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Entry as RowEntry;
+use Flow\ETL\Row\Entry\TypedCollection\Type;
 
 /**
  * @infection-ignore-all
@@ -128,6 +129,62 @@ class Entry
     final public static function json_object(string $name, array $data) : RowEntry
     {
         return RowEntry\JsonEntry::object($name, $data);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param array<bool> $value
+     *
+     * @throws \Flow\ETL\Exception\InvalidArgumentException
+     *
+     * @return RowEntry\ListEntry
+     */
+    final public static function list_of_boolean(string $name, array $value) : RowEntry
+    {
+        return new RowEntry\ListEntry($name, Type::boolean, $value);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param array<float> $value
+     *
+     * @throws \Flow\ETL\Exception\InvalidArgumentException
+     *
+     * @return RowEntry\ListEntry
+     */
+    final public static function list_of_float(string $name, array $value) : RowEntry
+    {
+        return new RowEntry\ListEntry($name, Type::float, $value);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param array<int> $value
+     *
+     * @throws \Flow\ETL\Exception\InvalidArgumentException
+     *
+     * @return RowEntry\ListEntry
+     */
+    final public static function list_of_int(string $name, array $value) : RowEntry
+    {
+        return new RowEntry\ListEntry($name, Type::integer, $value);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param array<string> $value
+     *
+     * @throws \Flow\ETL\Exception\InvalidArgumentException
+     *
+     * @return RowEntry\ListEntry
+     */
+    final public static function list_of_string(string $name, array $value) : RowEntry
+    {
+        return new RowEntry\ListEntry($name, Type::string, $value);
     }
 
     /**

--- a/src/Flow/ETL/DSL/Entry.php
+++ b/src/Flow/ETL/DSL/Entry.php
@@ -6,7 +6,7 @@ namespace Flow\ETL\DSL;
 
 use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Entry as RowEntry;
-use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
 
 /**
  * @infection-ignore-all
@@ -142,7 +142,7 @@ class Entry
      */
     final public static function list_of_boolean(string $name, array $value) : RowEntry
     {
-        return new RowEntry\ListEntry($name, Type::boolean, $value);
+        return new RowEntry\ListEntry($name, ScalarType::boolean, $value);
     }
 
     /**
@@ -156,7 +156,7 @@ class Entry
      */
     final public static function list_of_datetime(string $name, array $value) : RowEntry
     {
-        return new RowEntry\ListEntry($name, Type::datetime, $value);
+        return new RowEntry\ListEntry($name, new RowEntry\TypedCollection\ObjectType(\DateTimeInterface::class), $value);
     }
 
     /**
@@ -170,7 +170,7 @@ class Entry
      */
     final public static function list_of_float(string $name, array $value) : RowEntry
     {
-        return new RowEntry\ListEntry($name, Type::float, $value);
+        return new RowEntry\ListEntry($name, ScalarType::float, $value);
     }
 
     /**
@@ -184,7 +184,22 @@ class Entry
      */
     final public static function list_of_int(string $name, array $value) : RowEntry
     {
-        return new RowEntry\ListEntry($name, Type::integer, $value);
+        return new RowEntry\ListEntry($name, ScalarType::integer, $value);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param array<\DateTimeInterface> $value
+     * @param class-string $class
+     *
+     * @throws \Flow\ETL\Exception\InvalidArgumentException
+     *
+     * @return RowEntry\ListEntry
+     */
+    final public static function list_of_objects(string $name, string $class, array $value) : RowEntry
+    {
+        return new RowEntry\ListEntry($name, new RowEntry\TypedCollection\ObjectType($class), $value);
     }
 
     /**
@@ -198,7 +213,7 @@ class Entry
      */
     final public static function list_of_string(string $name, array $value) : RowEntry
     {
-        return new RowEntry\ListEntry($name, Type::string, $value);
+        return new RowEntry\ListEntry($name, ScalarType::string, $value);
     }
 
     /**

--- a/src/Flow/ETL/DSL/Transform.php
+++ b/src/Flow/ETL/DSL/Transform.php
@@ -18,6 +18,7 @@ use Flow\ETL\Transformer\Cast\CastToDateTime;
 use Flow\ETL\Transformer\Cast\CastToInteger;
 use Flow\ETL\Transformer\Cast\CastToJson;
 use Flow\ETL\Transformer\Cast\CastToString;
+use Flow\ETL\Transformer\Cast\EntryCaster\ArrayToListCaster;
 use Flow\ETL\Transformer\Cast\EntryCaster\DateTimeToStringEntryCaster;
 use Flow\ETL\Transformer\Cast\EntryCaster\StringToDateTimeEntryCaster;
 use Flow\ETL\Transformer\CastTransformer;
@@ -524,6 +525,61 @@ class Transform
     final public static function to_json(string ...$entries) : Transformer
     {
         return new CastTransformer(CastToJson::nullable($entries));
+    }
+
+    public static function to_list_boolean(string $entry) : Transformer
+    {
+        return new CastTransformer(
+            new Transformer\Cast\CastEntries(
+                [$entry],
+                new ArrayToListCaster(Entry\TypedCollection\ScalarType::boolean),
+                true
+            )
+        );
+    }
+
+    public static function to_list_datetime(string $entry) : Transformer
+    {
+        return new CastTransformer(
+            new Transformer\Cast\CastEntries(
+                [$entry],
+                new ArrayToListCaster(Entry\TypedCollection\ObjectType::of(\DateTimeInterface::class)),
+                true
+            )
+        );
+    }
+
+    public static function to_list_float(string $entry) : Transformer
+    {
+        return new CastTransformer(
+            new Transformer\Cast\CastEntries(
+                [$entry],
+                new ArrayToListCaster(Entry\TypedCollection\ScalarType::float),
+                true
+            )
+        );
+    }
+
+    public static function to_list_integer(string $entry) : Transformer
+    {
+        return new CastTransformer(
+            new Transformer\Cast\CastEntries(
+                [$entry],
+                new ArrayToListCaster(Entry\TypedCollection\ScalarType::integer),
+                true
+            )
+        );
+    }
+
+    public static function to_list_string(string $entry) : Transformer
+    {
+        return new CastTransformer(
+            new Transformer\Cast\CastEntries(
+                [$entry],
+                new ArrayToListCaster(Entry\TypedCollection\ScalarType::string),
+                true
+            )
+        );
     }
 
     final public static function to_null_from_null_string(string ...$entries) : Transformer

--- a/src/Flow/ETL/Row/Entry/ListEntry.php
+++ b/src/Flow/ETL/Row/Entry/ListEntry.php
@@ -33,8 +33,12 @@ final class ListEntry implements Entry, TypedCollection
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 
+        if (\count($value) && !\array_is_list($value)) {
+            throw new InvalidArgumentException('Expected list of ' . $type->toString() . ' got array with not sequential integer indexes');
+        }
+
         if (!$type->isValid($value)) {
-            throw new InvalidArgumentException('Expected list of ' . $type->name . ' got: ' . \implode(', ', $type->types($value)));
+            throw new InvalidArgumentException('Expected list of ' . $type->toString() . ' got different types.');
         }
     }
 
@@ -57,7 +61,7 @@ final class ListEntry implements Entry, TypedCollection
 
     public function definition() : Definition
     {
-        return Definition::list($this->name, $this->type, false);
+        return Definition::list($this->name, $this->type);
     }
 
     public function is(string $name) : bool
@@ -69,7 +73,7 @@ final class ListEntry implements Entry, TypedCollection
     {
         return $this->is($entry->name()) &&
             $entry instanceof self && (new ArrayComparison())->equals($this->value(), $entry->value())
-            && $this->type === $entry->type;
+            && $this->type->isEqual($entry->type);
     }
 
     public function map(callable $mapper) : Entry

--- a/src/Flow/ETL/Row/Entry/ListEntry.php
+++ b/src/Flow/ETL/Row/Entry/ListEntry.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Entry;
+
+use Flow\ArrayComparison\ArrayComparison;
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Schema\Definition;
+
+/**
+ * @template T
+ * @implements Entry<array<T>, array{name: string, type: Type, value: array<T>}>
+ * @psalm-immutable
+ */
+final class ListEntry implements Entry, TypedCollection
+{
+    /**
+     * @param string $name
+     * @param Type $type
+     * @param array<T> $value
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly Type $type,
+        private readonly array $value
+    ) {
+        if (!\strlen($name)) {
+            throw InvalidArgumentException::because('Entry name cannot be empty');
+        }
+
+        if (!$type->isValid($value)) {
+            throw new InvalidArgumentException('Expected list of ' . $type->name . ' got: ' . \implode(', ', $type->types($value)));
+        }
+    }
+
+    public function __serialize() : array
+    {
+        return ['name' => $this->name, 'type' => $this->type, 'value' => $this->value];
+    }
+
+    public function __toString() : string
+    {
+        return $this->toString();
+    }
+
+    public function __unserialize(array $data) : void
+    {
+        $this->name = $data['name'];
+        $this->type = $data['type'];
+        $this->value = $data['value'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::list($this->name, $this->type, false);
+    }
+
+    public function is(string $name) : bool
+    {
+        return $this->name === $name;
+    }
+
+    public function isEqual(Entry $entry) : bool
+    {
+        return $this->is($entry->name()) &&
+            $entry instanceof self && (new ArrayComparison())->equals($this->value(), $entry->value())
+            && $this->type === $entry->type;
+    }
+
+    public function map(callable $mapper) : Entry
+    {
+        return new self($this->name, $this->type, $mapper($this->value));
+    }
+
+    public function name() : string
+    {
+        return $this->name;
+    }
+
+    public function rename(string $name) : Entry
+    {
+        return new self($name, $this->type, $this->value);
+    }
+
+    public function toString() : string
+    {
+        return \json_encode($this->value(), JSON_THROW_ON_ERROR);
+    }
+
+    public function type() : Type
+    {
+        return $this->type;
+    }
+
+    public function value() : array
+    {
+        return $this->value;
+    }
+}

--- a/src/Flow/ETL/Row/Entry/TypedCollection.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL\Row\Entry;
+
+use Flow\ETL\Row\Entry\TypedCollection\Type;
+
+interface TypedCollection
+{
+    public function type() : Type;
+}

--- a/src/Flow/ETL/Row/Entry/TypedCollection/ObjectType.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/ObjectType.php
@@ -16,6 +16,7 @@ final class ObjectType implements Type
      */
     public function __construct(private readonly string $class)
     {
+        /** @psalm-suppress ImpureFunctionCall */
         if (!\class_exists($class) && !\interface_exists($this->class)) {
             throw new InvalidArgumentException("Class {$class} not found");
         }

--- a/src/Flow/ETL/Row/Entry/TypedCollection/ObjectType.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/ObjectType.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Entry\TypedCollection;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+
+final class ObjectType implements Type
+{
+    /**
+     * @param class-string $class
+     */
+    public function __construct(private readonly string $class)
+    {
+        if (!\class_exists($class) && !\interface_exists($this->class)) {
+            throw new InvalidArgumentException("Class {$class} not found");
+        }
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public static function of(string $class) : self
+    {
+        return new self($class);
+    }
+
+    public function isEqual(Type $type) : bool
+    {
+        return $type instanceof self && $type->class === $this->class;
+    }
+
+    public function isValid(array $collection) : bool
+    {
+        if (!\array_is_list($collection)) {
+            return false;
+        }
+
+        foreach ($collection as $value) {
+            if (!\is_object($value)) {
+                return false;
+            }
+
+            if (!$value instanceof $this->class) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function toString() : string
+    {
+        return 'object<' . $this->class . '>';
+    }
+}

--- a/src/Flow/ETL/Row/Entry/TypedCollection/ObjectType.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/ObjectType.php
@@ -6,6 +6,9 @@ namespace Flow\ETL\Row\Entry\TypedCollection;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 
+/**
+ * @psalm-immutable
+ */
 final class ObjectType implements Type
 {
     /**

--- a/src/Flow/ETL/Row/Entry/TypedCollection/ScalarType.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/ScalarType.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Entry\TypedCollection;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+
+enum ScalarType: string implements Type
+{
+    case boolean = 'boolean';
+    case float = 'float';
+    case integer = 'integer';
+    case string = 'string';
+
+    public static function fromString(string $value) : self
+    {
+        return match (\strtolower($value)) {
+            'integer' => self::integer,
+            'float', 'double' => self::float,
+            'string' => self::string,
+            'boolean' => self::boolean,
+            default => throw new InvalidArgumentException("Unsupported scalar type: {$value}")
+        };
+    }
+
+    public function isEqual(Type $type) : bool
+    {
+        return $type instanceof self && $type->value === $this->value;
+    }
+
+    public function isValid(array $collection) : bool
+    {
+        if (!\array_is_list($collection)) {
+            return false;
+        }
+
+        foreach ($collection as $value) {
+            if (!\is_scalar($value)) {
+                return false;
+            }
+
+            if ($this->value === 'float') {
+                // php gettype returns double for floats for historical reasons
+                if ('double' !== \gettype($value)) {
+                    return false;
+                }
+            } else {
+                if ($this->value !== \gettype($value)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public function toString() : string
+    {
+        return $this->value;
+    }
+}

--- a/src/Flow/ETL/Row/Entry/TypedCollection/ScalarType.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/ScalarType.php
@@ -6,6 +6,9 @@ namespace Flow\ETL\Row\Entry\TypedCollection;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 
+/**
+ * @psalm-immutable
+ */
 enum ScalarType: string implements Type
 {
     case boolean = 'boolean';

--- a/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
@@ -21,6 +21,7 @@ enum Type
      */
     public function isValid(array $collection) : bool
     {
+        /** @psalm-suppress ImpureVariable */
         if ($this === self::dateTime) {
             foreach ($collection as $item) {
                 if (!$item instanceof \DateTimeInterface) {

--- a/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
@@ -7,7 +7,7 @@ namespace Flow\ETL\Row\Entry\TypedCollection;
 enum Type
 {
     case boolean;
-    case dateTime;
+    case datetime;
     case float;
     case integer;
     case string;
@@ -22,7 +22,7 @@ enum Type
     public function isValid(array $collection) : bool
     {
         /** @psalm-suppress ImpureVariable */
-        if ($this === self::dateTime) {
+        if ($this === self::datetime) {
             foreach ($collection as $item) {
                 if (!$item instanceof \DateTimeInterface) {
                     return false;
@@ -55,9 +55,23 @@ enum Type
      */
     public function types(array $collection) : array
     {
-        return \array_map(
-            fn (string $value) => $value === 'double' ? 'float' : $value,
-            \array_unique(\array_map('gettype', $collection))
-        );
+        /** @var array<string> $types */
+        $types = [];
+
+        foreach ($collection as $value) {
+            $type = \gettype($value);
+
+            if ($value instanceof \DateTimeInterface) {
+                $type = 'datetime';
+            }
+
+            if ($type === 'double') {
+                $type = 'float';
+            }
+
+            $types[] = $type;
+        }
+
+        return \array_values(\array_unique($types));
     }
 }

--- a/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
@@ -58,6 +58,7 @@ enum Type
         /** @var array<string> $types */
         $types = [];
 
+        /** @psalm-suppress MixedAssignment */ 
         foreach ($collection as $value) {
             $type = \gettype($value);
 

--- a/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Entry\TypedCollection;
 
+/**
+ * @psalm-immutable
+ */
 interface Type
 {
     public function isEqual(self $type) : bool;
 
+    /**
+     * @param array<mixed> $collection
+     */
     public function isValid(array $collection) : bool;
 
     public function toString() : string;

--- a/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
@@ -4,75 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Entry\TypedCollection;
 
-enum Type
+interface Type
 {
-    case boolean;
-    case datetime;
-    case float;
-    case integer;
-    case string;
+    public function isEqual(self $type) : bool;
 
-    /**
-     * @psalm-pure
-     *
-     * @param array<mixed> $collection
-     *
-     * @return bool
-     */
-    public function isValid(array $collection) : bool
-    {
-        /** @psalm-suppress ImpureVariable */
-        if ($this === self::datetime) {
-            foreach ($collection as $item) {
-                if (!$item instanceof \DateTimeInterface) {
-                    return false;
-                }
-            }
+    public function isValid(array $collection) : bool;
 
-            return true;
-        }
-
-        /** @psalm-suppress ImpureVariable */
-        $types = $this->types($collection);
-
-        if (\count($types) === 1) {
-            /** @var string $type */
-            $type = \current($types) === 'double' ? 'float' : \current($types);
-
-            /** @psalm-suppress ImpureVariable */
-            return $this->name === $type;
-        }
-
-        return false;
-    }
-
-    /**
-     * @psalm-pure
-     *
-     * @param array<mixed> $collection
-     *
-     * @return array<string>
-     */
-    public function types(array $collection) : array
-    {
-        /** @var array<string> $types */
-        $types = [];
-
-        /** @psalm-suppress MixedAssignment */
-        foreach ($collection as $value) {
-            $type = \gettype($value);
-
-            if ($value instanceof \DateTimeInterface) {
-                $type = 'datetime';
-            }
-
-            if ($type === 'double') {
-                $type = 'float';
-            }
-
-            $types[] = $type;
-        }
-
-        return \array_values(\array_unique($types));
-    }
+    public function toString() : string;
 }

--- a/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Row\Entry\TypedCollection;
 enum Type
 {
     case boolean;
+    case dateTime;
     case float;
     case integer;
     case string;
@@ -20,6 +21,16 @@ enum Type
      */
     public function isValid(array $collection) : bool
     {
+        if ($this === self::dateTime) {
+            foreach ($collection as $item) {
+                if (!$item instanceof \DateTimeInterface) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         /** @psalm-suppress ImpureVariable */
         $types = $this->types($collection);
 

--- a/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Entry\TypedCollection;
+
+enum Type
+{
+    case boolean;
+    case float;
+    case integer;
+    case string;
+
+    /**
+     * @psalm-pure
+     *
+     * @param array<mixed> $collection
+     *
+     * @return bool
+     */
+    public function isValid(array $collection) : bool
+    {
+        /** @psalm-suppress ImpureVariable */
+        $types = $this->types($collection);
+
+        if (\count($types) === 1) {
+            /** @var string $type */
+            $type = \current($types) === 'double' ? 'float' : \current($types);
+
+            /** @psalm-suppress ImpureVariable */
+            return $this->name === $type;
+        }
+
+        return false;
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param array<mixed> $collection
+     *
+     * @return array<string>
+     */
+    public function types(array $collection) : array
+    {
+        return \array_map(
+            fn (string $value) => $value === 'double' ? 'float' : $value,
+            \array_unique(\array_map('gettype', $collection))
+        );
+    }
+}

--- a/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
+++ b/src/Flow/ETL/Row/Entry/TypedCollection/Type.php
@@ -58,7 +58,7 @@ enum Type
         /** @var array<string> $types */
         $types = [];
 
-        /** @psalm-suppress MixedAssignment */ 
+        /** @psalm-suppress MixedAssignment */
         foreach ($collection as $value) {
             $type = \gettype($value);
 

--- a/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -70,12 +70,14 @@ final class NativeEntryFactory implements EntryFactory
             $type = null;
             $class = null;
 
+            /** @psalm-suppress MixedAssignment */
             foreach ($value as $valueElement) {
                 if ($type === null) {
                     $type = \gettype($valueElement);
                 }
 
                 if ($type === 'object' && $class === null) {
+                    /** @psalm-suppress MixedArgument */
                     $class = \get_class($valueElement);
                 }
 
@@ -83,15 +85,24 @@ final class NativeEntryFactory implements EntryFactory
                     return new Row\Entry\ArrayEntry($entryName, $value);
                 }
 
+                /** @psalm-suppress MixedArgument */
                 if ($class !== null && $class !== \get_class($valueElement)) {
                     return new Row\Entry\ArrayEntry($entryName, $value);
                 }
             }
 
             if ($class !== null) {
+                /**
+                 * @psalm-suppress PossiblyNullArgument
+                 * @phpstan-ignore-next-line
+                 */
                 return new Entry\ListEntry($entryName, Entry\TypedCollection\ObjectType::of($class), $value);
             }
 
+            /**
+             * @psalm-suppress PossiblyNullArgument
+             * @phpstan-ignore-next-line
+             */
             return new Entry\ListEntry($entryName, Entry\TypedCollection\ScalarType::fromString($type), $value);
         }
 

--- a/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -63,7 +63,36 @@ final class NativeEntryFactory implements EntryFactory
         }
 
         if (\is_array($value)) {
-            return new Row\Entry\ArrayEntry($entryName, $value);
+            if (!\array_is_list($value)) {
+                return new Row\Entry\ArrayEntry($entryName, $value);
+            }
+
+            $type = null;
+            $class = null;
+
+            foreach ($value as $valueElement) {
+                if ($type === null) {
+                    $type = \gettype($valueElement);
+                }
+
+                if ($type === 'object' && $class === null) {
+                    $class = \get_class($valueElement);
+                }
+
+                if ($type !== \gettype($valueElement)) {
+                    return new Row\Entry\ArrayEntry($entryName, $value);
+                }
+
+                if ($class !== null && $class !== \get_class($valueElement)) {
+                    return new Row\Entry\ArrayEntry($entryName, $value);
+                }
+            }
+
+            if ($class !== null) {
+                return new Entry\ListEntry($entryName, Entry\TypedCollection\ObjectType::of($class), $value);
+            }
+
+            return new Entry\ListEntry($entryName, Entry\TypedCollection\ScalarType::fromString($type), $value);
         }
 
         if (null === $value) {

--- a/src/Flow/ETL/Row/Schema.php
+++ b/src/Flow/ETL/Row/Schema.php
@@ -92,12 +92,8 @@ final class Schema implements \Countable, Serializable
         foreach ($schema->definitions as $entry => $definition) {
             if (!\array_key_exists($definition->entry(), $newDefinitions)) {
                 $newDefinitions[$entry] = $definition->nullable();
-            }
-
-            if (!$newDefinitions[$entry]->isEqualType($definition)) {
-                $types = \array_unique(\array_merge($newDefinitions[$entry]->types(), $definition->types()));
-
-                $newDefinitions[$entry] = Definition::union($entry, $types);
+            } elseif (!$newDefinitions[$entry]->isEqual($definition)) {
+                $newDefinitions[$entry] = $definition->merge($newDefinitions[$entry]);
             }
         }
 

--- a/src/Flow/ETL/Row/Schema/Constraint/CollectionType.php
+++ b/src/Flow/ETL/Row/Schema/Constraint/CollectionType.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Schema\Constraint;
+
+use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Schema\Constraint;
+
+/**
+ * @implements Constraint<array{type: Type}>
+ */
+final class CollectionType implements Constraint
+{
+    public function __construct(private readonly Type $type)
+    {
+    }
+
+    public function __serialize() : array
+    {
+        return ['type' => $this->type];
+    }
+
+    public function __unserialize(array $data) : void
+    {
+        $this->type = $data['type'];
+    }
+
+    public function isSatisfiedBy(Entry $entry) : bool
+    {
+        if (!$entry instanceof Entry\TypedCollection) {
+            return false;
+        }
+
+        return $entry->type() === $this->type;
+    }
+}

--- a/src/Flow/ETL/Row/Schema/Constraint/NotEmpty.php
+++ b/src/Flow/ETL/Row/Schema/Constraint/NotEmpty.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Schema\Constraint;
+
+use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Schema\Constraint;
+
+/**
+ * @implements Constraint<array<mixed>>
+ */
+final class NotEmpty implements Constraint
+{
+    public function __construct()
+    {
+    }
+
+    public function __serialize() : array
+    {
+        return [];
+    }
+
+    public function __unserialize(array $data) : void
+    {
+    }
+
+    public function isSatisfiedBy(Entry $entry) : bool
+    {
+        /** @psalm-suppress MixedArgument */
+        return match (\get_class($entry)) {
+            Entry\ArrayEntry::class,
+            Entry\CollectionEntry::class,
+            Entry\StructureEntry::class,
+            /** @phpstan-ignore-next-line  */
+            Entry\ListEntry::class => (bool) \count($entry->value()),
+            Entry\StringEntry::class => $entry->value() !== '',
+            Entry\JsonEntry::class => !\in_array($entry->value(), ['', '[]', '{}'], true),
+            default => true, //everything else can't be empty
+        };
+    }
+}

--- a/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/Flow/ETL/Row/Schema/Definition.php
@@ -14,10 +14,14 @@ use Flow\ETL\Row\Entry\EnumEntry;
 use Flow\ETL\Row\Entry\FloatEntry;
 use Flow\ETL\Row\Entry\IntegerEntry;
 use Flow\ETL\Row\Entry\JsonEntry;
+use Flow\ETL\Row\Entry\ListEntry;
 use Flow\ETL\Row\Entry\NullEntry;
 use Flow\ETL\Row\Entry\ObjectEntry;
 use Flow\ETL\Row\Entry\StringEntry;
 use Flow\ETL\Row\Entry\StructureEntry;
+use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Schema\Constraint\All;
+use Flow\ETL\Row\Schema\Constraint\CollectionType;
 use Flow\Serializer\Serializable;
 
 /**
@@ -101,6 +105,21 @@ final class Definition implements Serializable
     public static function json(string $entry, bool $nullable = false, ?Constraint $constraint = null) : self
     {
         return new self($entry, ($nullable) ? [JsonEntry::class, NullEntry::class] : [JsonEntry::class], $constraint);
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
+     */
+    public static function list(string $entry, Type $type, bool $nullable = false, ?Constraint $constraint = null) : self
+    {
+        return new self(
+            $entry,
+            ($nullable) ? [ListEntry::class, ListEntry::class] : [ListEntry::class],
+            $constraint
+                ? new All(new CollectionType($type), $constraint)
+                : new CollectionType($type)
+        );
     }
 
     /**

--- a/src/Flow/ETL/Transformer/Cast/EntryCaster/ArrayToListCaster.php
+++ b/src/Flow/ETL/Transformer/Cast/EntryCaster/ArrayToListCaster.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Transformer\Cast\EntryCaster;
+
+use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\EntryConverter;
+
+/**
+ * @implements EntryConverter<array{type: Type}>
+ * @psalm-immutable
+ */
+final class ArrayToListCaster implements EntryConverter
+{
+    public function __construct(private readonly Type $type)
+    {
+    }
+
+    public function __serialize() : array
+    {
+        return ['type' => $this->type];
+    }
+
+    public function __unserialize(array $data) : void
+    {
+        $this->type = $data['type'];
+    }
+
+    public function convert(Entry $entry) : Entry
+    {
+        return new Entry\ListEntry(
+            $entry->name(),
+            $this->type,
+            (array) $entry->value()
+        );
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/ListEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/ListEntryTest.php
@@ -32,9 +32,9 @@ final class ListEntryTest extends TestCase
     public function test_creating_datetime_list_from_wrong_value_types() : void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected list of dateTime got: string, object');
+        $this->expectExceptionMessage('Expected list of datetime got: string, datetime');
 
-        new ListEntry('list', Type::dateTime, ['string', new \DateTimeImmutable()]);
+        new ListEntry('list', Type::datetime, ['string', new \DateTimeImmutable()]);
     }
 
     public function test_creating_float_list_from_wrong_value_types() : void

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/ListEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/ListEntryTest.php
@@ -29,6 +29,14 @@ final class ListEntryTest extends TestCase
         new ListEntry('list', Type::boolean, ['string', false]);
     }
 
+    public function test_creating_datetime_list_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected list of dateTime got: string, object');
+
+        new ListEntry('list', Type::dateTime, ['string', new \DateTimeImmutable()]);
+    }
+
     public function test_creating_float_list_from_wrong_value_types() : void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -98,6 +106,14 @@ final class ListEntryTest extends TestCase
         $this->assertEquals(
             '["one","two","three"]',
             Entry::list_of_string('strings', ['one', 'two', 'three'])->toString()
+        );
+    }
+
+    public function test_to_string_date_time() : void
+    {
+        $this->assertEquals(
+            '[{"date":"2021-01-01 00:00:00.000000","timezone_type":3,"timezone":"UTC"}]',
+            Entry::list_of_datetime('strings', [new \DateTimeImmutable('2021-01-01 00:00:00')])->toString()
         );
     }
 

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/ListEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/ListEntryTest.php
@@ -7,7 +7,8 @@ namespace Flow\ETL\Tests\Unit\Row\Entry;
 use Flow\ETL\DSL\Entry;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry\ListEntry;
-use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Entry\TypedCollection\ObjectType;
+use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
 use Flow\ETL\Row\Schema\Definition;
 use PHPUnit\Framework\TestCase;
 
@@ -24,47 +25,55 @@ final class ListEntryTest extends TestCase
     public function test_creating_boolean_list_from_wrong_value_types() : void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected list of boolean got: string, boolean');
+        $this->expectExceptionMessage('Expected list of boolean got different types');
 
-        new ListEntry('list', Type::boolean, ['string', false]);
+        new ListEntry('list', ScalarType::boolean, ['string', false]);
     }
 
     public function test_creating_datetime_list_from_wrong_value_types() : void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected list of datetime got: string, datetime');
+        $this->expectExceptionMessage('Expected list of object<DateTimeInterface> got different types.');
 
-        new ListEntry('list', Type::datetime, ['string', new \DateTimeImmutable()]);
+        new ListEntry('list', new ObjectType(\DateTimeInterface::class), ['string', new \DateTimeImmutable()]);
     }
 
     public function test_creating_float_list_from_wrong_value_types() : void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected list of float got: string, float');
+        $this->expectExceptionMessage('Expected list of float got different types');
 
-        new ListEntry('list', Type::float, ['string', 1.3]);
+        new ListEntry('list', ScalarType::float, ['string', 1.3]);
     }
 
     public function test_creating_integer_list_from_wrong_value_types() : void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected list of integer got: string, integer');
+        $this->expectExceptionMessage('Expected list of integer got different types');
 
-        new ListEntry('list', Type::integer, ['string', 1]);
+        new ListEntry('list', ScalarType::integer, ['string', 1]);
+    }
+
+    public function test_creating_list_from_not_list_array() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected list of integer got array with not sequential integer indexes');
+
+        new ListEntry('list', ScalarType::integer, ['a' => 1, 'b' => 2]);
     }
 
     public function test_creating_string_list_from_wrong_value_types() : void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected list of string got: string, integer');
+        $this->expectExceptionMessage('Expected list of string got different types');
 
-        new ListEntry('list', Type::string, ['string', 1]);
+        new ListEntry('list', ScalarType::string, ['string', 1]);
     }
 
     public function test_definition() : void
     {
         $this->assertEquals(
-            Definition::list('strings', Type::string, false),
+            Definition::list('strings', ScalarType::string, false),
             Entry::list_of_string('strings', ['one', 'two', 'three'])->definition()
         );
     }
@@ -120,7 +129,7 @@ final class ListEntryTest extends TestCase
     public function test_type() : void
     {
         $this->assertEquals(
-            Type::string,
+            ScalarType::string,
             Entry::list_of_string('strings', ['one', 'two', 'three'])->type()
         );
     }

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/ListEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/ListEntryTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Entry;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Row\Entry\ListEntry;
+use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Schema\Definition;
+use PHPUnit\Framework\TestCase;
+
+final class ListEntryTest extends TestCase
+{
+    public function test_create_with_empty_name() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Entry name cannot be empty');
+
+        Entry::list_of_string('', ['one', 'two', 'three']);
+    }
+
+    public function test_creating_boolean_list_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected list of boolean got: string, boolean');
+
+        new ListEntry('list', Type::boolean, ['string', false]);
+    }
+
+    public function test_creating_float_list_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected list of float got: string, float');
+
+        new ListEntry('list', Type::float, ['string', 1.3]);
+    }
+
+    public function test_creating_integer_list_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected list of integer got: string, integer');
+
+        new ListEntry('list', Type::integer, ['string', 1]);
+    }
+
+    public function test_creating_string_list_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected list of string got: string, integer');
+
+        new ListEntry('list', Type::string, ['string', 1]);
+    }
+
+    public function test_definition() : void
+    {
+        $this->assertEquals(
+            Definition::list('strings', Type::string, false),
+            Entry::list_of_string('strings', ['one', 'two', 'three'])->definition()
+        );
+    }
+
+    public function test_is_equal() : void
+    {
+        $this->assertTrue(
+            Entry::list_of_string('strings', ['one', 'two', 'three'])
+                ->isEqual(Entry::list_of_string('strings', ['one', 'two', 'three']))
+        );
+        $this->assertFalse(
+            Entry::list_of_string('strings', ['one', 'two', 'three'])
+                ->isEqual(Entry::list_of_int('strings', [1, 2, 3]))
+        );
+        $this->assertTrue(
+            Entry::list_of_string('strings', ['two', 'one', 'three'])
+                ->isEqual(Entry::list_of_string('strings', ['one', 'two', 'three']))
+        );
+    }
+
+    public function test_map() : void
+    {
+        $this->assertEquals(
+            Entry::list_of_string('strings', ['one, two, three']),
+            Entry::list_of_string('strings', ['one', 'two', 'three'])->map(fn (array $value) => [\implode(', ', $value)])
+        );
+    }
+
+    public function test_rename() : void
+    {
+        $this->assertEquals(
+            Entry::list_of_string('new_name', ['one', 'two', 'three']),
+            Entry::list_of_string('strings', ['one', 'two', 'three'])->rename('new_name')
+        );
+    }
+
+    public function test_to_string() : void
+    {
+        $this->assertEquals(
+            '["one","two","three"]',
+            Entry::list_of_string('strings', ['one', 'two', 'three'])->toString()
+        );
+    }
+
+    public function test_type() : void
+    {
+        $this->assertEquals(
+            Type::string,
+            Entry::list_of_string('strings', ['one', 'two', 'three'])->type()
+        );
+    }
+
+    public function test_value() : void
+    {
+        $this->assertEquals(
+            ['one', 'two', 'three'],
+            Entry::list_of_string('strings', ['one', 'two', 'three'])->value()
+        );
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -10,35 +10,11 @@ use PHPUnit\Framework\TestCase;
 
 final class NativeEntryFactoryTest extends TestCase
 {
-    public function test_string() : void
+    public function test_array() : void
     {
         $this->assertEquals(
-            Entry::string('e', 'test'),
-            (new NativeEntryFactory())->create('e', 'test')
-        );
-    }
-
-    public function test_json() : void
-    {
-        $this->assertEquals(
-            Entry::json('e', ["id" => 1]),
-            (new NativeEntryFactory())->create('e', '{"id":1}')
-        );
-    }
-
-    public function test_float() : void
-    {
-        $this->assertEquals(
-            Entry::float('e', 1.1),
-            (new NativeEntryFactory())->create('e', 1.1)
-        );
-    }
-
-    public function test_int() : void
-    {
-        $this->assertEquals(
-            Entry::integer('e', 1),
-            (new NativeEntryFactory())->create('e', 1)
+            Entry::array('e', ['a' => 1, 'b' => 2]),
+            (new NativeEntryFactory())->create('e', ['a' => 1, 'b' => 2])
         );
     }
 
@@ -58,27 +34,27 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
-    public function test_object() : void
+    public function test_float() : void
     {
         $this->assertEquals(
-            Entry::object('e', $object = new \ArrayIterator([1, 2])),
-            (new NativeEntryFactory())->create('e', $object)
+            Entry::float('e', 1.1),
+            (new NativeEntryFactory())->create('e', 1.1)
         );
     }
 
-    public function test_array() : void
+    public function test_int() : void
     {
         $this->assertEquals(
-            Entry::array('e', ['a' => 1, 'b' => 2]),
-            (new NativeEntryFactory())->create('e', ['a' => 1, 'b' => 2])
+            Entry::integer('e', 1),
+            (new NativeEntryFactory())->create('e', 1)
         );
     }
 
-    public function test_list_of_scalars() : void
+    public function test_json() : void
     {
         $this->assertEquals(
-            Entry::list_of_int('e', [1, 2]),
-            (new NativeEntryFactory())->create('e', [1, 2])
+            Entry::json('e', ['id' => 1]),
+            (new NativeEntryFactory())->create('e', '{"id":1}')
         );
     }
 
@@ -90,11 +66,35 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
+    public function test_list_of_scalars() : void
+    {
+        $this->assertEquals(
+            Entry::list_of_int('e', [1, 2]),
+            (new NativeEntryFactory())->create('e', [1, 2])
+        );
+    }
+
     public function test_null() : void
     {
         $this->assertEquals(
             Entry::null('e'),
             (new NativeEntryFactory())->create('e', null)
+        );
+    }
+
+    public function test_object() : void
+    {
+        $this->assertEquals(
+            Entry::object('e', $object = new \ArrayIterator([1, 2])),
+            (new NativeEntryFactory())->create('e', $object)
+        );
+    }
+
+    public function test_string() : void
+    {
+        $this->assertEquals(
+            Entry::string('e', 'test'),
+            (new NativeEntryFactory())->create('e', 'test')
         );
     }
 }

--- a/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Factory;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Row\Factory\NativeEntryFactory;
+use PHPUnit\Framework\TestCase;
+
+final class NativeEntryFactoryTest extends TestCase
+{
+    public function test_string() : void
+    {
+        $this->assertEquals(
+            Entry::string('e', 'test'),
+            (new NativeEntryFactory())->create('e', 'test')
+        );
+    }
+
+    public function test_json() : void
+    {
+        $this->assertEquals(
+            Entry::json('e', ["id" => 1]),
+            (new NativeEntryFactory())->create('e', '{"id":1}')
+        );
+    }
+
+    public function test_float() : void
+    {
+        $this->assertEquals(
+            Entry::float('e', 1.1),
+            (new NativeEntryFactory())->create('e', 1.1)
+        );
+    }
+
+    public function test_int() : void
+    {
+        $this->assertEquals(
+            Entry::integer('e', 1),
+            (new NativeEntryFactory())->create('e', 1)
+        );
+    }
+
+    public function test_bool() : void
+    {
+        $this->assertEquals(
+            Entry::boolean('e', false),
+            (new NativeEntryFactory())->create('e', false)
+        );
+    }
+
+    public function test_datetime() : void
+    {
+        $this->assertEquals(
+            Entry::datetime('e', $now = new \DateTimeImmutable()),
+            (new NativeEntryFactory())->create('e', $now)
+        );
+    }
+
+    public function test_object() : void
+    {
+        $this->assertEquals(
+            Entry::object('e', $object = new \ArrayIterator([1, 2])),
+            (new NativeEntryFactory())->create('e', $object)
+        );
+    }
+
+    public function test_array() : void
+    {
+        $this->assertEquals(
+            Entry::array('e', ['a' => 1, 'b' => 2]),
+            (new NativeEntryFactory())->create('e', ['a' => 1, 'b' => 2])
+        );
+    }
+
+    public function test_list_of_scalars() : void
+    {
+        $this->assertEquals(
+            Entry::list_of_int('e', [1, 2]),
+            (new NativeEntryFactory())->create('e', [1, 2])
+        );
+    }
+
+    public function test_list_of_datetimes() : void
+    {
+        $this->assertEquals(
+            Entry::list_of_objects('e', \DateTimeImmutable::class, $list = [new \DateTimeImmutable(), new \DateTimeImmutable()]),
+            (new NativeEntryFactory())->create('e', $list)
+        );
+    }
+
+    public function test_null() : void
+    {
+        $this->assertEquals(
+            Entry::null('e'),
+            (new NativeEntryFactory())->create('e', null)
+        );
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Row/Schema/Constraint/CollectionTypeTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Schema/Constraint/CollectionTypeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Schema\Constraint;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Schema\Constraint\CollectionType;
+use PHPUnit\Framework\TestCase;
+
+final class CollectionTypeTest extends TestCase
+{
+    public function test_against_invalid_typed_collection() : void
+    {
+        $this->assertFalse((new CollectionType(Type::integer))->isSatisfiedBy(Entry::list_of_string('id', ['one', 'two'])));
+    }
+
+    public function test_against_not_typed_collection() : void
+    {
+        $this->assertFalse((new CollectionType(Type::string))->isSatisfiedBy(Entry::integer('id', 1)));
+    }
+
+    public function test_against_valid_typed_collection() : void
+    {
+        $this->assertTrue((new CollectionType(Type::string))->isSatisfiedBy(Entry::list_of_string('id', ['one', 'two'])));
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Row/Schema/Constraint/CollectionTypeTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Schema/Constraint/CollectionTypeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Row\Schema\Constraint;
 
 use Flow\ETL\DSL\Entry;
-use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
 use Flow\ETL\Row\Schema\Constraint\CollectionType;
 use PHPUnit\Framework\TestCase;
 
@@ -13,16 +13,16 @@ final class CollectionTypeTest extends TestCase
 {
     public function test_against_invalid_typed_collection() : void
     {
-        $this->assertFalse((new CollectionType(Type::integer))->isSatisfiedBy(Entry::list_of_string('id', ['one', 'two'])));
+        $this->assertFalse((new CollectionType(ScalarType::integer))->isSatisfiedBy(Entry::list_of_string('id', ['one', 'two'])));
     }
 
     public function test_against_not_typed_collection() : void
     {
-        $this->assertFalse((new CollectionType(Type::string))->isSatisfiedBy(Entry::integer('id', 1)));
+        $this->assertFalse((new CollectionType(ScalarType::string))->isSatisfiedBy(Entry::integer('id', 1)));
     }
 
     public function test_against_valid_typed_collection() : void
     {
-        $this->assertTrue((new CollectionType(Type::string))->isSatisfiedBy(Entry::list_of_string('id', ['one', 'two'])));
+        $this->assertTrue((new CollectionType(ScalarType::string))->isSatisfiedBy(Entry::list_of_string('id', ['one', 'two'])));
     }
 }

--- a/tests/Flow/ETL/Tests/Unit/Row/Schema/Constraint/NotEmptyTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Schema/Constraint/NotEmptyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Schema\Constraint;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Row\Entries;
+use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
+use Flow\ETL\Row\Schema\Constraint\NotEmpty;
+use PHPUnit\Framework\TestCase;
+
+final class NotEmptyTest extends TestCase
+{
+    public function test_not_empty_is_not_satisfied() : void
+    {
+        $constraint = new NotEmpty();
+
+        $this->assertFalse($constraint->isSatisfiedBy(Entry::array('e', [])));
+        $this->assertFalse($constraint->isSatisfiedBy(Entry::collection('e')));
+        $this->assertFalse($constraint->isSatisfiedBy(Entry::json('e', [])));
+        $this->assertFalse($constraint->isSatisfiedBy(Entry::json_object('e', [])));
+        $this->assertFalse($constraint->isSatisfiedBy(Entry::list_of_int('e', [])));
+        $this->assertFalse($constraint->isSatisfiedBy(Entry::structure('e')));
+    }
+
+    public function test_not_empty_is_satisfied() : void
+    {
+        $constraint = new NotEmpty();
+
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::array('e', [1])));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::boolean('e', false)));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::collection('e', new Entries())));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::datetime('e', new \DateTimeImmutable())));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::enum('e', ScalarType::integer)));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::float('e', 1.1)));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::integer('e', 1)));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::json('e', [1, 2])));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::list_of_int('e', [1, 2])));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::null('e')));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::object('e', new \SplFixedArray(2))));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::string('e', 'e')));
+        $this->assertTrue($constraint->isSatisfiedBy(Entry::structure('e', Entry::integer('id', 1))));
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -7,7 +7,10 @@ namespace Flow\ETL\Tests\Unit\Row\Schema;
 use Flow\ETL\DSL\Entry;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry\IntegerEntry;
+use Flow\ETL\Row\Entry\ListEntry;
+use Flow\ETL\Row\Entry\NullEntry;
 use Flow\ETL\Row\Entry\StringEntry;
+use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
 use Flow\ETL\Row\Schema\Constraint;
 use Flow\ETL\Row\Schema\Definition;
 use PHPUnit\Framework\TestCase;
@@ -22,19 +25,41 @@ final class DefinitionTest extends TestCase
         new Definition('name', []);
     }
 
-    public function test_equal_types() : void
+    public function test_equals() : void
     {
         $def = Definition::union('test', [IntegerEntry::class, StringEntry::class]);
 
         $this->assertTrue(
-            $def->isEqualType(
+            $def->isEqual(
                 Definition::union('test', [StringEntry::class, IntegerEntry::class])
             )
         );
 
         $this->assertFalse(
-            $def->isEqualType(
+            $def->isEqual(
                 Definition::boolean('test', false)
+            )
+        );
+    }
+
+    public function test_equals_but_different_constraints() : void
+    {
+        $def = Definition::list('list', ScalarType::integer);
+
+        $this->assertFalse(
+            $def->isEqual(
+                Definition::list('list', ScalarType::string)
+            )
+        );
+    }
+
+    public function test_equals_types_and_constraints() : void
+    {
+        $def = Definition::list('list', ScalarType::integer);
+
+        $this->assertTrue(
+            $def->isEqual(
+                Definition::list('list', ScalarType::integer)
             )
         );
     }
@@ -63,6 +88,75 @@ final class DefinitionTest extends TestCase
         $def = Definition::integer('test');
 
         $this->assertTrue($def->matches(Entry::integer('test', 1)));
+    }
+
+    public function test_merge_definitions_with_both_side_constraints() : void
+    {
+        $this->assertEquals(
+            Definition::union(
+                'id',
+                [IntegerEntry::class, StringEntry::class],
+                new Constraint\Any(
+                    new Constraint\SameAs(1),
+                    new Constraint\SameAs('one')
+                )
+            )->nullable(),
+            Definition::integer('id', false, new Constraint\SameAs(1))
+                ->merge(Definition::string('id', true, new Constraint\SameAs('one')))
+        );
+    }
+
+    public function test_merge_definitions_with_left_side_constraints() : void
+    {
+        $this->assertEquals(
+            Definition::union('id', [StringEntry::class, IntegerEntry::class], new Constraint\SameAs(1))->nullable(),
+            Definition::string('id', false, new Constraint\SameAs(1))->merge(Definition::integer('id', true))
+        );
+    }
+
+    public function test_merge_definitions_with_right_side_constraints() : void
+    {
+        $this->assertEquals(
+            Definition::union('id', [StringEntry::class, IntegerEntry::class], new Constraint\SameAs(2))->nullable(),
+            Definition::string('id', false)->merge(Definition::integer('id', true, new Constraint\SameAs(2)))
+        );
+    }
+
+    public function test_merge_definitions_without_constraints() : void
+    {
+        $this->assertEquals(
+            Definition::union('id', [StringEntry::class, IntegerEntry::class])->nullable(),
+            Definition::string('id', false)->merge(Definition::integer('id', true))
+        );
+    }
+
+    public function test_merge_list_definitions_with_both_side_constraints() : void
+    {
+        $this->assertEquals(
+            Definition::union(
+                'list',
+                [ListEntry::class],
+                new Constraint\Any(
+                    new Constraint\CollectionType(ScalarType::string),
+                    new Constraint\CollectionType(ScalarType::integer),
+                )
+            ),
+            Definition::list('list', ScalarType::string)
+                ->merge(Definition::list('list', ScalarType::integer))
+        );
+    }
+
+    public function test_merging_two_different_lists_should_give_another_list() : void
+    {
+        $this->assertEquals(
+            new Definition(
+                'list',
+                [ListEntry::class, NullEntry::class],
+                new Constraint\Any(new Constraint\CollectionType(ScalarType::integer), new Constraint\CollectionType(ScalarType::string))
+            ),
+            Definition::list('list', ScalarType::integer)
+                ->merge(Definition::list('list', ScalarType::string, true))
+        );
     }
 
     public function test_not_matches_when_constraint_not_satisfied() : void

--- a/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -15,6 +15,7 @@ use Flow\ETL\Row\Entry\IntegerEntry;
 use Flow\ETL\Row\Entry\NullEntry;
 use Flow\ETL\Row\Entry\ObjectEntry;
 use Flow\ETL\Row\Entry\StringEntry;
+use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
 use Flow\ETL\Row\Schema;
 use Flow\ETL\Row\Schema\Definition;
 use Flow\ETL\Rows;
@@ -514,7 +515,7 @@ final class RowsTest extends TestCase
     {
         $rows = new Rows(
             Row::create(Entry::integer('id', 1), Entry::string('name', 'foo')),
-            Row::create(Entry::integer('id', 1), Entry::null('name')),
+            Row::create(Entry::integer('id', 1), Entry::null('name'), Entry::list_of_int('list', [1, 2])),
             Row::create(Entry::integer('id', 1), Entry::string('name', 'bar'), Entry::array('tags', ['a', 'b'])),
             Row::create(Entry::integer('id', 1), Entry::integer('name', 25)),
         );
@@ -522,8 +523,9 @@ final class RowsTest extends TestCase
         $this->assertEquals(
             new Schema(
                 Definition::integer('id'),
-                Definition::union('name', [StringEntry::class, NullEntry::class, IntegerEntry::class]),
-                Definition::array('tags', $nullable = true)
+                Definition::union('name', [IntegerEntry::class, StringEntry::class, NullEntry::class]),
+                Definition::array('tags', $nullable = true),
+                Definition::list('list', ScalarType::integer, $nullable = true)
             ),
             $rows->schema()
         );

--- a/tests/Flow/ETL/Tests/Unit/Transformer/ArrayUnpackTransformerTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Transformer/ArrayUnpackTransformerTest.php
@@ -8,6 +8,7 @@ use Flow\ETL\DSL\Transform;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
+use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
 use Flow\ETL\Rows;
 use PHPUnit\Framework\TestCase;
 
@@ -83,7 +84,7 @@ final class ArrayUnpackTransformerTest extends TestCase
                     new Row\Entry\StringEntry('status', 'PENDING'),
                     new Row\Entry\BooleanEntry('enabled', true),
                     new Row\Entry\DateTimeEntry('datetime', new \DateTimeImmutable('2020-01-01 00:00:00 UTC')),
-                    new Row\Entry\ArrayEntry('array', ['foo', 'bar']),
+                    new Row\Entry\ListEntry('array', ScalarType::string, ['foo', 'bar']),
                     new Row\Entry\JsonEntry('json', ['foo', 'bar']),
                     new Row\Entry\ObjectEntry('object', new \stdClass()),
                     new Row\Entry\NullEntry('null'),
@@ -126,7 +127,7 @@ final class ArrayUnpackTransformerTest extends TestCase
                     new Row\Entry\StringEntry('1', 'PENDING'),
                     new Row\Entry\BooleanEntry('2', true),
                     new Row\Entry\DateTimeEntry('3', new \DateTimeImmutable('2020-01-01 00:00:00 UTC')),
-                    new Row\Entry\ArrayEntry('4', ['foo', 'bar']),
+                    new Row\Entry\ListEntry('4', ScalarType::string, ['foo', 'bar']),
                     new Row\Entry\JsonEntry('5', ['foo', 'bar']),
                     new Row\Entry\ObjectEntry('6', new \stdClass()),
                     new Row\Entry\NullEntry('7'),

--- a/tests/Flow/ETL/Tests/Unit/Transformer/CallUserFunctionTransformerTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Transformer/CallUserFunctionTransformerTest.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Tests\Unit\Transformer;
 use Flow\ETL\DSL\Transform;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
 use Flow\ETL\Rows;
 use PHPUnit\Framework\TestCase;
 
@@ -174,7 +175,7 @@ final class CallUserFunctionTransformerTest extends TestCase
 
         $this->assertEquals(new Rows(
             Row::create(
-                new Row\Entry\ArrayEntry('array_list', [1, 2, 3, 4]),
+                new Row\Entry\ListEntry('array_list', ScalarType::integer, [1, 2, 3, 4]),
             )
         ), $rows);
     }
@@ -203,7 +204,7 @@ final class CallUserFunctionTransformerTest extends TestCase
 
         $this->assertEquals(new Rows(
             Row::create(
-                new Row\Entry\ArrayEntry('array_list', [1, 2, 3, 4]),
+                new Row\Entry\ListEntry('array_list', ScalarType::integer, [1, 2, 3, 4]),
             )
         ), $rows);
     }

--- a/tests/Flow/ETL/Tests/Unit/Transformer/CastTransformerTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Transformer/CastTransformerTest.php
@@ -29,6 +29,18 @@ final class CastTransformerTest extends TestCase
         $this->assertSame('{"foo":"bar"}', $rows->first()->valueOf('collection'));
     }
 
+    public function test_cast_array_to_list() : void
+    {
+        $entry = new ArrayEntry('collection', ['foo', 'bar']);
+
+        $transformer = Transform::to_list_string('collection');
+
+        $rows = $transformer->transform(new Rows(new Row(new Row\Entries($entry))));
+
+        $this->assertInstanceOf(Row\Entry\ListEntry::class, $rows->first()->get('collection'));
+        $this->assertSame(['foo', 'bar'], $rows->first()->valueOf('collection'));
+    }
+
     public function test_casts_multiple_entries_with_null_entry_in_betwee() : void
     {
         $transformer = Transform::to_integer('id', 'limit', 'current');


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>ListEntry with a strong typing that supports scalar types and objects/interfaces</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>[BC Break] Native entry factory will check if array is a list of a single type and it will try to create ListEntry instead of ArrayEntry</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

ListEntry is pretty much a strongly typed flat ArrayEntry that validates input value. 

One of the use cases for strongly typed lists is Parquet file format support which can't handle PHP arrays but works just fine with strongly typed flat arrays. 