### PR TITLE
Added default metadata to EnumEntry type

### DIFF
--- a/src/Flow/ETL/Row/Entry/EnumEntry.php
+++ b/src/Flow/ETL/Row/Entry/EnumEntry.php
@@ -41,10 +41,10 @@ final class EnumEntry implements Entry
 
     public function definition() : Definition
     {
+        /** @psalm-suppress ImpureMethodCall */
         return Definition::enum(
             $this->name,
-            metadata: Metadata::empty()
-                ->add(Definition::METADATA_ENUM_CASES, $this->value::cases())
+            metadata: Metadata::with(Definition::METADATA_ENUM_CASES, $this->value::cases())
         );
     }
 

--- a/src/Flow/ETL/Row/Entry/EnumEntry.php
+++ b/src/Flow/ETL/Row/Entry/EnumEntry.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Row\Entry;
 
 use Flow\ETL\Row\Entry;
 use Flow\ETL\Row\Schema\Definition;
+use Flow\ETL\Row\Schema\Metadata;
 
 /**
  * @implements Entry<\UnitEnum, array{name: string, value: \UnitEnum}>
@@ -40,7 +41,11 @@ final class EnumEntry implements Entry
 
     public function definition() : Definition
     {
-        return Definition::enum($this->name);
+        return Definition::enum(
+            $this->name,
+            metadata: Metadata::empty()
+                ->add(Definition::METADATA_ENUM_CASES, $this->value::cases())
+        );
     }
 
     public function is(string $name) : bool

--- a/src/Flow/ETL/Row/Entry/ListEntry.php
+++ b/src/Flow/ETL/Row/Entry/ListEntry.php
@@ -66,8 +66,7 @@ final class ListEntry implements Entry, TypedCollection
         return Definition::list(
             $this->name,
             $this->type,
-            metadata: Metadata::empty()
-                ->add(Definition::METADATA_LIST_ENTRY_TYPE, $this->type())
+            metadata: Metadata::with(Definition::METADATA_LIST_ENTRY_TYPE, $this->type())
         );
     }
 

--- a/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/Flow/ETL/Row/Schema/Definition.php
@@ -35,6 +35,8 @@ use Flow\Serializer\Serializable;
  */
 final class Definition implements Serializable
 {
+    public const METADATA_ENUM_CASES = 'flow_enum_vales';
+
     public const METADATA_LIST_ENTRY_TYPE = 'flow_list_entry_type';
 
     private Constraint $constraint;

--- a/src/Flow/ETL/Row/Schema/Metadata.php
+++ b/src/Flow/ETL/Row/Schema/Metadata.php
@@ -32,6 +32,17 @@ final class Metadata implements Serializable
         return new self([]);
     }
 
+    /**
+     * @param string $key
+     * @param array<mixed>|bool|float|int|object|string $value
+     *
+     * @return $this
+     */
+    public static function with(string $key, int|string|bool|float|object|array $value) : self
+    {
+        return new self([$key => $value]);
+    }
+
     public function __serialize() : array
     {
         return [

--- a/tests/Flow/ETL/Tests/Unit/Row/Entry/EnumEntryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/Row/Entry/EnumEntryTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Row\Entry\EnumEntry;
 use Flow\ETL\Row\Schema\Definition;
+use Flow\ETL\Row\Schema\Metadata;
 use Flow\ETL\Tests\Fixtures\Enum\BackedIntEnum;
 use Flow\ETL\Tests\Fixtures\Enum\BackedStringEnum;
 use Flow\ETL\Tests\Fixtures\Enum\BasicEnum;
@@ -55,7 +56,7 @@ final class EnumEntryTest extends TestCase
     public function test_definition() : void
     {
         $this->assertEquals(
-            Definition::enum('enum'),
+            Definition::enum('enum', metadata: Metadata::with(Definition::METADATA_ENUM_CASES, BackedStringEnum::cases())),
             (new EnumEntry('enum', BackedStringEnum::one))->definition()
         );
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>default metadata to EnumEntry type</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->