### PR TITLE
Fixed wrong name comparison in `CollectionEntry` class

### DIFF
--- a/src/Flow/ETL/Row/Entry/CollectionEntry.php
+++ b/src/Flow/ETL/Row/Entry/CollectionEntry.php
@@ -26,7 +26,7 @@ final class CollectionEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name, Entries ...$entries)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 
@@ -59,7 +59,7 @@ final class CollectionEntry implements \Stringable, Entry
 
     public function is(string $name) : bool
     {
-        return $name === $name;
+        return $name === $this->name;
     }
 
     public function isEqual(Entry $entry) : bool


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fixed wrong name comparison in `CollectionEntry` class</li>
  </ul>
</div>
<hr/>

<h2>Description</h2>

`CollectionEntry::is($name)` method was broken as internally it always compared passed value with precisely the same passed value, not with the `$name` passed into the class constructor.