### PR TITLE
Function `uniqid()` must be used with 2nd parameter to increase uniqueness

### DIFF
--- a/src/Flow/ETL/Async/Socket/Worker/ClientProtocol.php
+++ b/src/Flow/ETL/Async/Socket/Worker/ClientProtocol.php
@@ -20,7 +20,7 @@ final class ClientProtocol
     public function __construct(private readonly Processor $processor)
     {
         $this->cache = new InMemoryCache();
-        $this->cacheId = \uniqid('flow_async_pipeline');
+        $this->cacheId = \uniqid('flow_async_pipeline', true);
     }
 
     public function handle(string $id, Message $message, Server $server) : void

--- a/src/Flow/ETL/ConfigBuilder.php
+++ b/src/Flow/ETL/ConfigBuilder.php
@@ -37,7 +37,7 @@ final class ConfigBuilder
      */
     public function build() : Config
     {
-        $this->id ??= \uniqid('flow_php');
+        $this->id ??= \uniqid('flow_php', true);
         $this->serializer ??= new CompressingSerializer();
         $this->cache ??= new LocalFilesystemCache(
             \is_string(\getenv(Config::CACHE_DIR_ENV))

--- a/src/Flow/ETL/Pipeline/LocalSocketPipeline.php
+++ b/src/Flow/ETL/Pipeline/LocalSocketPipeline.php
@@ -55,7 +55,7 @@ final class LocalSocketPipeline implements Pipeline
     {
         $pool = Pool::generate($this->totalWorkers);
 
-        $id = \uniqid('flow_async_pipeline');
+        $id = \uniqid('flow_async_pipeline', true);
 
         $this->server->initialize(new ServerProtocol($config, $id, $pool, $this->extractor, $this->pipes));
 

--- a/src/Flow/ETL/Stream/Handler.php
+++ b/src/Flow/ETL/Stream/Handler.php
@@ -33,7 +33,7 @@ final class Handler
     {
         /** @psalm-suppress PossiblyNullOperand */
         $fullPath = ($this->safeMode)
-            ? (\rtrim($stream->uri(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . \uniqid() . '.' . $this->extension)
+            ? (\rtrim($stream->uri(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . \uniqid('', true) . '.' . $this->extension)
             : $stream->uri();
 
         $context = \count($stream->options())

--- a/src/Flow/ETL/Stream/Handler.php
+++ b/src/Flow/ETL/Stream/Handler.php
@@ -25,22 +25,17 @@ final class Handler
     }
 
     /**
-     * @param FileStream $stream
-     *
      * @return resource
      */
     public function open(FileStream $stream, Mode $mode)
     {
-        /** @psalm-suppress PossiblyNullOperand */
-        $fullPath = ($this->safeMode)
-            ? (\rtrim($stream->uri(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . \uniqid('', true) . '.' . $this->extension)
-            : $stream->uri();
-
         $context = \count($stream->options())
             ? \stream_context_create([$stream->scheme() => $stream->options()])
             : null;
 
         if ($this->safeMode) {
+            $fullPath = (\rtrim($stream->uri(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . \bin2hex(\random_bytes(13)) . '.' . ($this->extension ?: ''));
+
             if ($stream instanceof LocalFile) {
                 if (!\file_exists($stream->uri())) {
                     $context
@@ -52,6 +47,8 @@ final class Handler
                     ? \mkdir(\rtrim($stream->uri(), DIRECTORY_SEPARATOR), 0777, true, $context)
                     : \mkdir(\rtrim($stream->uri(), DIRECTORY_SEPARATOR), 0777, true);
             }
+        } else {
+            $fullPath = $stream->uri();
         }
 
         $resource = $context


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Function `uniqid()` must be used with 2nd parameter to increase uniqueness</li>
  </ul>
</div>
<hr/>

<h2>Description</h2>

According to [the official documentation](https://www.php.net/manual/en/function.uniqid.php):
> Warning
> This function does not guarantee uniqueness of return value. Since most systems adjust system clock by NTP or like, system time is changed constantly. Therefore, it is possible that this function does not return unique ID for the process/thread. Use `more_entropy` to increase likelihood of uniqueness.