### PR TITLE
Fixed `Handler` class to not use `0777` mode & reduce code duplicates

### DIFF
--- a/src/Flow/ETL/Stream/Handler.php
+++ b/src/Flow/ETL/Stream/Handler.php
@@ -16,7 +16,7 @@ final class Handler
 
     public static function directory(string $extension) : self
     {
-        return new self(true, $extension);
+        return new self(true, \ltrim($extension, '.'));
     }
 
     public static function file() : self
@@ -34,26 +34,25 @@ final class Handler
             : null;
 
         if ($this->safeMode) {
-            $fullPath = (\rtrim($stream->uri(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . \bin2hex(\random_bytes(13)) . '.' . ($this->extension ?: ''));
+            $dirname = \rtrim($stream->uri(), DIRECTORY_SEPARATOR);
+            $fullPath = $dirname . DIRECTORY_SEPARATOR . \bin2hex(\random_bytes(13)) . '.' . ($this->extension ?: '');
 
             if ($stream instanceof LocalFile) {
                 if (!\file_exists($stream->uri())) {
                     $context
-                        ? \mkdir(\rtrim($stream->uri(), DIRECTORY_SEPARATOR), 0777, true, $context)
-                        : \mkdir(\rtrim($stream->uri(), DIRECTORY_SEPARATOR), 0777, true);
+                        ? \mkdir($dirname, 0755, true, $context)
+                        : \mkdir($dirname, 0755, true);
                 }
             } else {
                 $context
-                    ? \mkdir(\rtrim($stream->uri(), DIRECTORY_SEPARATOR), 0777, true, $context)
-                    : \mkdir(\rtrim($stream->uri(), DIRECTORY_SEPARATOR), 0777, true);
+                    ? \mkdir($dirname, 0755, true, $context)
+                    : \mkdir($dirname, 0755, true);
             }
         } else {
             $fullPath = $stream->uri();
         }
 
-        $resource = $context
-            ? \fopen($fullPath, $mode->value, false, $context)
-            : \fopen($fullPath, $mode->value);
+        $resource = \fopen($fullPath, $mode->value, null !== $context, $context);
 
         if ($resource === false) {
             throw new RuntimeException("Unable to open stream for path {$stream->uri()}.");

--- a/tests/Flow/ETL/Tests/Integration/Stream/HandlerTest.php
+++ b/tests/Flow/ETL/Tests/Integration/Stream/HandlerTest.php
@@ -13,23 +13,41 @@ final class HandlerTest extends TestCase
 {
     public function test_directory_handler() : void
     {
-        $handler = Handler::directory('json');
-
-        $resource = $handler->open(new LocalFile(\sys_get_temp_dir() . '/nested/directory'), Mode::WRITE);
+        $resource = Handler::directory('json')
+            ->open(new LocalFile(\sys_get_temp_dir() . '/nested/directory'), Mode::WRITE);
 
         $this->assertIsResource($resource);
 
-        \fclose($resource);
+        @\unlink($this->getFileNameFromResource($resource));
+    }
+
+    public function test_directory_handler_without_double_dot() : void
+    {
+        $resource = Handler::directory('.json')
+            ->open(new LocalFile(\sys_get_temp_dir() . '/nested/directory'), Mode::WRITE);
+
+        $fileName = $this->getFileNameFromResource($resource);
+
+        $this->assertStringNotContainsString('..json', $fileName);
+
+        @\unlink($fileName);
     }
 
     public function test_file_handler() : void
     {
-        $handler = Handler::file();
-
-        $resource = $handler->open(new LocalFile(\sys_get_temp_dir() . '/file.json'), Mode::WRITE);
+        $resource = Handler::file()
+            ->open(new LocalFile(\sys_get_temp_dir() . '/file.json'), Mode::WRITE);
 
         $this->assertIsResource($resource);
 
-        \fclose($resource);
+        @\unlink($this->getFileNameFromResource($resource));
+    }
+
+    /**
+     * @param resource $resource
+     */
+    private function getFileNameFromResource($resource) : string
+    {
+        return \stream_get_meta_data($resource)['uri'];
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Changed</h4>
  <ul id="changed">
    <li>Prevent duplicate `.` in extension name</li>
    <li>Reduce duplicate calls to `->uri()` method</li>
  </ul> 
  <h4>Security</h4>
  <ul id="removed">
    <li>Changed file/directory mask from 0777 to 0755</li>
  </ul> 
</div>
<hr/>

<h2>Description</h2>

Removed potential security issue with chmod `0777`, improved `Handler` class by reducing duplications & added cleanup to its test.